### PR TITLE
Fix issue 926: Only accept card clicks outside EditText when editable.

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ChunkModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ChunkModeAdapter.java
@@ -264,7 +264,9 @@ public class ChunkModeAdapter extends ViewModeAdapter<ChunkModeAdapter.ViewHolde
             public void onClick(View v) {
                 boolean actionTaken = openTargetTranslationCard(holder, position);
 
-                if (!actionTaken) {
+                // Accept clicks anywhere on card as if they were on the text box --
+                // but only if the text is actually editable (i.e., not yet done).
+                if (!actionTaken && holder.mTargetBody.isEnabled()) {
                     holder.mTargetBody.requestFocus();
 
                     InputMethodManager mgr = (InputMethodManager)


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/930)
<!-- Reviewable:end -->
