### PR TITLE
 Fix #1005 - make keyboard close when users mark the focused frame as done. 

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
@@ -621,6 +621,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                                     if (finished) {
                                         item.isEditing = false;
                                         item.renderedTargetBody = null;
+                                        getListener().closeKeyboard();
                                         notifyDataSetChanged();
                                     } else {
                                         Snackbar snack = Snackbar.make(mContext.findViewById(android.R.id.content), R.string.translate_first, Snackbar.LENGTH_LONG);


### PR DESCRIPTION
 Fix #1005 - make keyboard close when users mark the focused frame as done.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1020)
<!-- Reviewable:end -->
