### PR TITLE
Fix Issue #776 - Custom Alert Dialog - Hide Title if not set.

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/dialogs/CustomAlertDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/dialogs/CustomAlertDialog.java
@@ -130,9 +130,11 @@ public class CustomAlertDialog extends DialogFragment {
             final TextView title = (TextView) rootView.findViewById(R.id.dialog_title);
             title.setText(mTitleID);
         }
+        TextView title = (TextView) rootView.findViewById(R.id.dialog_title);
         if(mTitle != null) {
-            TextView title = (TextView) rootView.findViewById(R.id.dialog_title);
             title.setText(mTitle);
+        } else { // if not set then hide
+            title.setVisibility(View.GONE);
         }
 
         return rootView;


### PR DESCRIPTION
Fix Issue #776 - Custom Alert Dialog

Here is a small fix to the Custom Alert Dialog.  It currently shows a title of "Title" if the title is not set.
This fix will hide the title if not set.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1131)
<!-- Reviewable:end -->
