### PR TITLE
Fix issue #1222 Problem with verse mark order checking in review mode

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
@@ -613,6 +613,9 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                             .setPositiveButton(R.string.confirm, new View.OnClickListener() {
                                         @Override
                                         public void onClick(View v) {
+                                            if(!item.isEditing) { // make sure to capture verse marker changes
+                                                item.renderedTargetBody = holder.mTargetEditableBody.getText();
+                                            }
                                             boolean success = onConfirmChunk(item, chapter, frame);
                                             holder.mDoneSwitch.setChecked(success);
                                         }


### PR DESCRIPTION
Fix issue #1222 Problem with verse mark order checking in review mode.  
Make sure to capture verse marker changes when not in edit mode and before verifying chunk.

@neutrinog - looks like this is working right.  But you may want to review this fix.