### PR TITLE
Fix #1360 do not allow adding footnotes to Bible titles and references

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
@@ -710,8 +710,10 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                 }
             };
             thread.start();
+
+            boolean allowFootnote = mAllowFootnote && item.isFrame();
             holder.mEditButton.setImageResource(R.drawable.ic_done_black_24dp);
-            holder.mAddNoteButton.setVisibility(mAllowFootnote ? View.VISIBLE : View.GONE);
+            holder.mAddNoteButton.setVisibility(allowFootnote ? View.VISIBLE : View.GONE);
             holder.mUndoButton.setVisibility(View.GONE);
             holder.mRedoButton.setVisibility(View.GONE);
             holder.mTargetBody.setVisibility(View.GONE);

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
@@ -102,6 +102,8 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
     private boolean mResourcesOpened = false;
     private ContentValues[] mTabs;
     private int[] mOpenResourceTab;
+    private boolean mAllowFootnote = true;
+
 //    private boolean onBind = false;
 
     public ReviewModeAdapter(Activity context, String targetTranslationId, String sourceTranslationId, String startingChapterSlug, String startingFrameSlug, boolean resourcesOpened) {
@@ -111,6 +113,8 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
         mContext = context;
         mTargetTranslation = mTranslator.getTargetTranslation(targetTranslationId);
         mSourceTranslation = mLibrary.getSourceTranslation(sourceTranslationId);
+        boolean isOBS = mSourceTranslation.projectSlug.equals("obs");
+        mAllowFootnote = !isOBS;
         mSourceLanguage = mLibrary.getSourceLanguage(mSourceTranslation.projectSlug, mSourceTranslation.sourceLanguageSlug);
         mTargetLanguage = mLibrary.getTargetLanguage(mTargetTranslation.getTargetLanguageId());
         mResourcesOpened = resourcesOpened;
@@ -707,7 +711,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
             };
             thread.start();
             holder.mEditButton.setImageResource(R.drawable.ic_done_black_24dp);
-            holder.mAddNoteButton.setVisibility(View.VISIBLE);
+            holder.mAddNoteButton.setVisibility(mAllowFootnote ? View.VISIBLE : View.GONE);
             holder.mUndoButton.setVisibility(View.GONE);
             holder.mRedoButton.setVisibility(View.GONE);
             holder.mTargetBody.setVisibility(View.GONE);

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
@@ -113,8 +113,8 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
         mContext = context;
         mTargetTranslation = mTranslator.getTargetTranslation(targetTranslationId);
         mSourceTranslation = mLibrary.getSourceTranslation(sourceTranslationId);
-        boolean isOBS = mSourceTranslation.projectSlug.equals("obs");
-        mAllowFootnote = !isOBS;
+        boolean usfm = mTargetTranslation.getFormat() == TranslationFormat.USFM;
+        mAllowFootnote = usfm;
         mSourceLanguage = mLibrary.getSourceLanguage(mSourceTranslation.projectSlug, mSourceTranslation.sourceLanguageSlug);
         mTargetLanguage = mLibrary.getTargetLanguage(mTargetTranslation.getTargetLanguageId());
         mResourcesOpened = resourcesOpened;


### PR DESCRIPTION
Fix #1360 do not allow adding footnotes to Bible titles and references

This also includes "Fix #1359 do not allow footnotes in obs" otherwise would have a merge conflict.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1391)
<!-- Reviewable:end -->
