### PR TITLE
Fix #1371- verse markers are not rendered in the target translation while in read mode

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ChunkModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ChunkModeAdapter.java
@@ -803,7 +803,7 @@ public class ChunkModeAdapter extends ViewModeAdapter<ChunkModeAdapter.ViewHolde
                 }
             };
             ClickableRenderingEngine renderer = Clickables.setupRenderingGroup(format, renderingGroup, null, noteClickListener, true);
-            renderer.setVersesEnabled(true);
+            renderer.setVersesEnabled(false);
 
         } else {
             // TODO: add note click listener

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ChunkModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ChunkModeAdapter.java
@@ -803,7 +803,7 @@ public class ChunkModeAdapter extends ViewModeAdapter<ChunkModeAdapter.ViewHolde
                 }
             };
             ClickableRenderingEngine renderer = Clickables.setupRenderingGroup(format, renderingGroup, null, noteClickListener, true);
-            renderer.setVersesEnabled(false);
+            renderer.setVersesEnabled(true);
 
         } else {
             // TODO: add note click listener

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReadModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReadModeAdapter.java
@@ -297,7 +297,7 @@ public class ReadModeAdapter extends ViewModeAdapter<ReadModeAdapter.ViewHolder>
 
         // render the target chapter body
         if(mRenderedTargetBody[position] == null) {
-            TranslationFormat bodyFormat = mLibrary.getChapterBodyFormat(mSourceTranslation, chapter.getId());
+            TranslationFormat bodyFormat = mTargetTranslation.getFormat();
             String chapterBody = "";
             String[] frameSlugs = mLibrary.getFrameSlugs(mSourceTranslation, chapter.getId());
             for (String frameSlug : frameSlugs) {
@@ -308,7 +308,8 @@ public class ReadModeAdapter extends ViewModeAdapter<ReadModeAdapter.ViewHolder>
             RenderingGroup targetRendering = new RenderingGroup();
             if(Clickables.isClickableFormat(bodyFormat)) {
                 // TODO: add click listeners
-                Clickables.setupRenderingGroup(bodyFormat, targetRendering, null, null, true);
+                ClickableRenderingEngine renderer = Clickables.setupRenderingGroup(bodyFormat, targetRendering, null, null, true);
+                renderer.setVersesEnabled(true);
             } else {
                 targetRendering.addEngine(new DefaultRenderer());
             }


### PR DESCRIPTION
Fix #1371- verse markers are not rendered in the target translation while in read mode

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1393)
<!-- Reviewable:end -->