### PR TITLE
Issue1421

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,7 +19,7 @@ android {
         applicationId "com.translationstudio.androidapp"
         minSdkVersion 15
         targetSdkVersion 23
-        versionCode 120
+        versionCode 121
         versionName "6.1"
         multiDexEnabled = true
     }

--- a/app/src/androidTest/assets/schema.sql
+++ b/app/src/androidTest/assets/schema.sql
@@ -32,7 +32,25 @@ CREATE TABLE `project` (
   `source_language_catalog_url` TEXT NOT NULL,
   `source_language_catalog_local_modified_at` INTEGER NOT NULL DEFAULT 0,
   `source_language_catalog_server_modified_at` INTEGER NOT NULL DEFAULT 0,
+  `chunk_marker_catalog_url` TEXT NOT NULL,
+  `chunk_marker_catalog_local_modified_at` INTEGER NOT NULL DEFAULT 0,
+  `chunk_marker_catalog_server_modified_at` INTEGER NOT NULL DEFAULT 0
   UNIQUE (`slug`)
+);
+
+-- ---
+-- Table 'chunk_marker'
+-- ---
+
+DROP TABLE IF EXISTS `chunk_marker`;
+
+CREATE TABLE `chunk_marker` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `project_id` INTEGER NOT NULL,
+  `chapter_slug` TEXT NOT NULL,
+  `first_verse_slug` TEXT NOT NULL,
+  UNIQUE (`project_id`, 'chapter_slug', 'first_verse_slug'),
+  FOREIGN KEY (project_id) REFERENCES `project` (`id`) ON DELETE CASCADE
 );
 
 -- ---

--- a/app/src/androidTest/assets/schema.sql
+++ b/app/src/androidTest/assets/schema.sql
@@ -34,7 +34,7 @@ CREATE TABLE `project` (
   `source_language_catalog_server_modified_at` INTEGER NOT NULL DEFAULT 0,
   `chunk_marker_catalog_url` TEXT NULL DEFAULT NULL,
   `chunk_marker_catalog_local_modified_at` INTEGER NOT NULL DEFAULT 0,
-  `chunk_marker_catalog_server_modified_at` INTEGER NOT NULL DEFAULT 0
+  `chunk_marker_catalog_server_modified_at` INTEGER NOT NULL DEFAULT 0,
   UNIQUE (`slug`)
 );
 

--- a/app/src/androidTest/assets/schema.sql
+++ b/app/src/androidTest/assets/schema.sql
@@ -32,7 +32,7 @@ CREATE TABLE `project` (
   `source_language_catalog_url` TEXT NOT NULL,
   `source_language_catalog_local_modified_at` INTEGER NOT NULL DEFAULT 0,
   `source_language_catalog_server_modified_at` INTEGER NOT NULL DEFAULT 0,
-  `chunk_marker_catalog_url` TEXT NOT NULL,
+  `chunk_marker_catalog_url` TEXT NULL DEFAULT NULL,
   `chunk_marker_catalog_local_modified_at` INTEGER NOT NULL DEFAULT 0,
   `chunk_marker_catalog_server_modified_at` INTEGER NOT NULL DEFAULT 0
   UNIQUE (`slug`)

--- a/app/src/androidTest/java/com/door43/translationstudio/IndexerTest.java
+++ b/app/src/androidTest/java/com/door43/translationstudio/IndexerTest.java
@@ -6,6 +6,7 @@ import android.test.InstrumentationTestCase;
 import com.door43.tools.reporting.Logger;
 import com.door43.translationstudio.MainApplication;
 import com.door43.translationstudio.core.CheckingQuestion;
+import com.door43.translationstudio.core.ChunkMarker;
 import com.door43.translationstudio.core.Indexer;
 import com.door43.translationstudio.core.IndexerSQLiteHelper;
 import com.door43.translationstudio.core.SourceTranslation;
@@ -154,5 +155,10 @@ public class IndexerTest extends InstrumentationTestCase {
         assertTrue(mIndex.indexTranslationAcademy(translation, catalog));
         mIndex.endTransaction(true);
         // TODO: 12/4/2015 test retrieving an article
+    }
+
+    public void test09ChunkMarkers() throws Exception {
+        ChunkMarker[] markers = mIndex.getChunkMarkers("gen");
+        assertTrue(markers.length > 0);
     }
 }

--- a/app/src/main/assets/schema.sql
+++ b/app/src/main/assets/schema.sql
@@ -32,7 +32,25 @@ CREATE TABLE `project` (
   `source_language_catalog_url` TEXT NOT NULL,
   `source_language_catalog_local_modified_at` INTEGER NOT NULL DEFAULT 0,
   `source_language_catalog_server_modified_at` INTEGER NOT NULL DEFAULT 0,
+  `chunk_marker_catalog_url` TEXT NOT NULL,
+  `chunk_marker_catalog_local_modified_at` INTEGER NOT NULL DEFAULT 0,
+  `chunk_marker_catalog_server_modified_at` INTEGER NOT NULL DEFAULT 0,
   UNIQUE (`slug`)
+);
+
+
+-- ---
+-- Table 'chunk_marker'
+-- ---
+
+DROP TABLE IF EXISTS `chunk_marker`;
+
+CREATE TABLE `chunk_marker` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `project_id` INTEGER NOT NULL,
+  `chapter_slug` TEXT NOT NULL,
+  `first_verse_slug` TEXT NOT NULL,
+  FOREIGN KEY (project_id) REFERENCES `project` (`id`) ON DELETE CASCADE
 );
 
 -- ---

--- a/app/src/main/java/com/door43/translationstudio/DeveloperToolsActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/DeveloperToolsActivity.java
@@ -432,7 +432,19 @@ public class DeveloperToolsActivity extends BaseActivity implements ManagedTask.
 
         if(task instanceof GetLibraryUpdatesTask) {
             if(task.getTaskId().equals(INDEX_CHUNK_MARKERS_TASK_ID)) {
-
+                if(mDownloadProgressDialog != null && mDownloadProgressDialog.isShowing()) {
+                    mDownloadProgressDialog.dismiss();
+                }
+                mDownloadProgressDialog = null;
+                if(!task.isCanceled()) {
+                    CustomAlertDialog.Create(DeveloperToolsActivity.this)
+                            .setTitle(R.string.success)
+                            .setIcon(R.drawable.ic_done_black_24dp)
+                            .setMessage("Chunk Markers have been indexed")
+                            .setCancelableChainable(false)
+                            .setPositiveButton(R.string.label_ok, null)
+                            .show("Success");
+                }
             } else {
                 DownloadAllProjectsTask newTask = new DownloadAllProjectsTask();
                 newTask.addOnProgressListener(this);

--- a/app/src/main/java/com/door43/translationstudio/DeveloperToolsActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/DeveloperToolsActivity.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 
 public class DeveloperToolsActivity extends BaseActivity implements ManagedTask.OnProgressListener, ManagedTask.OnFinishedListener, DialogInterface.OnCancelListener {
 
+    public static final String INDEX_CHUNK_MARKERS_TASK_ID = "index_chunk_markers";
     private static final String TASK_PREP_FORCE_DOWNLOAD_ALL_PROJECTS = "prep_force_download_all_projects";
     private ArrayList<ToolItem> mDeveloperTools = new ArrayList<>();
     private ToolAdapter mAdapter;
@@ -239,7 +240,7 @@ public class DeveloperToolsActivity extends BaseActivity implements ManagedTask.
                             }
                         })
                         .setNegativeButton(R.string.no, null)
-                        .show("DownldAll");
+                        .show("DownloadAll");
             }
         }));
         mDeveloperTools.add(new ToolItem("Index tA", "Indexes the bundled tA json", 0, new ToolItem.ToolAction() {
@@ -285,6 +286,49 @@ public class DeveloperToolsActivity extends BaseActivity implements ManagedTask.
                 Snackbar snack = Snackbar.make(findViewById(android.R.id.content), "indexing tA...", Snackbar.LENGTH_LONG);
                 ViewUtil.setSnackBarTextColor(snack, getResources().getColor(R.color.light_primary_text));
                 snack.show();
+            }
+        }));
+        mDeveloperTools.add(new ToolItem("Index Chunk Markers", "Injects the chunk marker catalog url into the database and runs the update check", 0, new ToolItem.ToolAction() {
+            @Override
+            public void run() {
+                // manually inject chunk marker details into db
+                AppContext.getLibrary().manuallyInjectChunkMarkerCatalogUrl();
+
+                // run update check to index the chunk markers
+                GetLibraryUpdatesTask task = new GetLibraryUpdatesTask();
+                task.addOnProgressListener(DeveloperToolsActivity.this);
+                task.addOnFinishedListener(DeveloperToolsActivity.this);
+                TaskManager.addTask(task, INDEX_CHUNK_MARKERS_TASK_ID);
+//                ThreadableUI thread = new ThreadableUI(DeveloperToolsActivity.this) {
+//                    @Override
+//                    public void onStop() {
+//
+//                    }
+//
+//                    @Override
+//                    public void run() {
+//                        // manually inject chunk marker details into db
+//
+//                        // run update check to index the chunk markers
+//                        GetLibraryUpdatesTask task = new GetLibraryUpdatesTask();
+//                        task.addOnProgressListener(DeveloperToolsActivity.this);
+//                        task.addOnFinishedListener(DeveloperToolsActivity.this);
+//                        TaskManager.addTask(task, "just_check_for_updates");
+//                    }
+//
+//                    @Override
+//                    public void onPostExecute() {
+//                        CustomAlertDialog.Create(DeveloperToolsActivity.this)
+//                                .setTitle(R.string.success)
+//                                .setMessage("chunk markers has been indexed")
+//                                .setNeutralButton(R.string.dismiss, null)
+//                                .show("chunk-index-success");
+//                    }
+//                };
+//                thread.start();
+//                Snackbar snack = Snackbar.make(findViewById(android.R.id.content), "indexing chunk markers...", Snackbar.LENGTH_LONG);
+//                ViewUtil.setSnackBarTextColor(snack, getResources().getColor(R.color.light_primary_text));
+//                snack.show();
             }
         }));
         mDeveloperTools.add(new ToolItem(getResources().getString(R.string.export_source), getResources().getString(R.string.export_source_description), 0, new ToolItem.ToolAction() {
@@ -368,6 +412,10 @@ public class DeveloperToolsActivity extends BaseActivity implements ManagedTask.
     public void connectDownloadAllTask() {
         DownloadAllProjectsTask downloadAllTask = (DownloadAllProjectsTask)TaskManager.getTask(DownloadAllProjectsTask.TASK_ID);
         GetLibraryUpdatesTask getUpdatesTask = (GetLibraryUpdatesTask)TaskManager.getTask(GetLibraryUpdatesTask.TASK_ID);
+        if(getUpdatesTask == null) {
+            getUpdatesTask = (GetLibraryUpdatesTask)TaskManager.getTask(INDEX_CHUNK_MARKERS_TASK_ID);
+        }
+
         if(downloadAllTask != null) {
             downloadAllTask.addOnProgressListener(this);
             downloadAllTask.addOnFinishedListener(this);
@@ -383,10 +431,14 @@ public class DeveloperToolsActivity extends BaseActivity implements ManagedTask.
         TaskManager.clearTask(task);
 
         if(task instanceof GetLibraryUpdatesTask) {
-            DownloadAllProjectsTask newTask = new DownloadAllProjectsTask();
-            newTask.addOnProgressListener(this);
-            newTask.addOnFinishedListener(this);
-            TaskManager.addTask(newTask, DownloadAllProjectsTask.TASK_ID);
+            if(task.getTaskId().equals(INDEX_CHUNK_MARKERS_TASK_ID)) {
+
+            } else {
+                DownloadAllProjectsTask newTask = new DownloadAllProjectsTask();
+                newTask.addOnProgressListener(this);
+                newTask.addOnFinishedListener(this);
+                TaskManager.addTask(newTask, DownloadAllProjectsTask.TASK_ID);
+            }
         }
 
         if(task instanceof DownloadAllProjectsTask) {

--- a/app/src/main/java/com/door43/translationstudio/core/ChunkMarker.java
+++ b/app/src/main/java/com/door43/translationstudio/core/ChunkMarker.java
@@ -1,0 +1,15 @@
+package com.door43.translationstudio.core;
+
+/**
+ * Represents a single chunk marker
+ */
+public class ChunkMarker {
+
+    public final String chapterSlug;
+    public final String firstVerseSlug;
+
+    public ChunkMarker(String chapterSlug, String firstVerseSlug) {
+        this.chapterSlug = chapterSlug;
+        this.firstVerseSlug = firstVerseSlug;
+    }
+}

--- a/app/src/main/java/com/door43/translationstudio/core/Downloader.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Downloader.java
@@ -108,8 +108,30 @@ public class Downloader {
     }
 
     /**
+     * Downloads the chunk markers for a project from the server
+     * @param projectSlug
+     * @param targetIndex
+     * @return
+     */
+    public boolean downloadChunkMarkerList(String projectSlug, Indexer targetIndex) {
+        Project project = targetIndex.getProject(projectSlug);
+        if(project != null && project.chunkMarkerCatalog != null
+                && (project.chunkMarkerCatalogLocalDateModified < project.chunkMarkerCatalogServerDateModified
+                || project.chunkMarkerCatalogServerDateModified == 0)) {
+            String catalog = request(project.chunkMarkerCatalog);
+            if(catalog != null) {
+                if(targetIndex.indexChunkMarkers(projectSlug, catalog)) {
+                    targetIndex.markChunkMarkerCatalogUpToDate(projectSlug);
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
      * Downloads the source languages for a project from the server
      * @param projectSlug
+     * @param targetIndex
      * @return
      */
     public boolean downloadSourceLanguageList(String projectSlug, Indexer targetIndex) {
@@ -260,7 +282,7 @@ public class Downloader {
      * @param targetIndex the index to which the chunks will be downloaded
      * @return
      */
-    public boolean downloadChunks(String projectSlug, Indexer targetIndex) {
+    public boolean downloadChunkMarkers(String projectSlug, Indexer targetIndex) {
 //        Resource resource = targetIndex.getResource(project);
         String catalog = request("https://api.unfoldingword.org/bible/txt/1/" + projectSlug + "/chunks.json");
         // TODO: 4/5/2016 once chunks are properly in the catalog we can use the code below
@@ -269,7 +291,7 @@ public class Downloader {
 //                || resource.getChunksDateModified() == 0)) {
 //            String catalog = request(resource.getChunksCatalogUrl());
             if(catalog != null) {
-                return targetIndex.indexChunks(projectSlug, catalog);
+                return targetIndex.indexChunkMarkers(projectSlug, catalog);
             } else {
                 Logger.w(this.getClass().getName(), "Failed to fetch the catalog from " + catalog);
             }

--- a/app/src/main/java/com/door43/translationstudio/core/Downloader.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Downloader.java
@@ -254,6 +254,29 @@ public class Downloader {
         return true;
     }
 
+    /**
+     * Downloads the chunks for the source translation from the server
+     * @param projectSlug
+     * @param targetIndex the index to which the chunks will be downloaded
+     * @return
+     */
+    public boolean downloadChunks(String projectSlug, Indexer targetIndex) {
+//        Resource resource = targetIndex.getResource(project);
+        String catalog = request("https://api.unfoldingword.org/bible/txt/1/" + projectSlug + "/chunks.json");
+        // TODO: 4/5/2016 once chunks are properly in the catalog we can use the code below
+//        if(resource != null && resource.getChunksCatalogUrl() != null
+//                && (resource.getChunksDateModified() < resource.getChunksServerDateModified()
+//                || resource.getChunksDateModified() == 0)) {
+//            String catalog = request(resource.getChunksCatalogUrl());
+            if(catalog != null) {
+                return targetIndex.indexChunks(projectSlug, catalog);
+            } else {
+                Logger.w(this.getClass().getName(), "Failed to fetch the catalog from " + catalog);
+            }
+//        }
+        return false;
+    }
+
     public boolean downloadImages(Library.OnProgressListener listener) {
         // TODO: 1/21/2016 we need to be sure to download images for the correct project. right now only obs has images
         // eventually the api will be updated so we can easily download the correct images.

--- a/app/src/main/java/com/door43/translationstudio/core/Indexer.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Indexer.java
@@ -1308,4 +1308,13 @@ public class Indexer {
     public boolean manuallyInjectChunkMarkerUrls() {
         return mDatabaseHelper.manuallyInjectChunkMarkerUrls(mDatabase);
     }
+
+    /**
+     * Returns an array of chunk markers for the project
+     * @param projectSlug
+     * @return
+     */
+    public ChunkMarker[] getChunkMarkers(String projectSlug) {
+        return mDatabaseHelper.getChunkMarkers(mDatabase, projectSlug);
+    }
 }

--- a/app/src/main/java/com/door43/translationstudio/core/Indexer.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Indexer.java
@@ -156,7 +156,7 @@ public class Indexer {
         try {
             items = new JSONArray(catalog);
         } catch (JSONException e) {
-            Logger.e(this.getClass().getName(), "Failed to the projects catalog", e);
+            Logger.e(this.getClass().getName(), "Failed to parse the projects catalog", e);
             return false;
         }
 
@@ -170,6 +170,7 @@ public class Indexer {
                     for(int j = 0; j < categoriesJson.length(); j ++) {
                         categorySlugs.add(categoriesJson.getString(j));
                     }
+                    // TODO: eventually we will pass in the chunk marker catalog info
                     mDatabaseHelper.addProject(mDatabase, project.getId(), project.sort, project.dateModified, project.sourceLanguageCatalog, project.sourceLanguageCatalogServerDateModified, categorySlugs.toArray(new String[categorySlugs.size()]));
                     mDatabase.yieldIfContendedSafely();
                 }

--- a/app/src/main/java/com/door43/translationstudio/core/Indexer.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Indexer.java
@@ -366,6 +366,10 @@ public class Indexer {
         mDatabaseHelper.markWordAssignmentsCatalogUpToDate(mDatabase, sourceTranslation.projectSlug, sourceTranslation.sourceLanguageSlug, sourceTranslation.resourceSlug);
     }
 
+    public synchronized void markChunkMarkerCatalogUpToDate(String projectSlug) {
+        mDatabaseHelper.markChunkMarkerCatalogUpToDate(mDatabase, projectSlug);
+    }
+
     /**
      * Builds a source index from json
      * @param sourceTranslation
@@ -797,12 +801,12 @@ public class Indexer {
      * @param catalog
      * @return
      */
-    public synchronized boolean indexChunks(String projectSlug, String catalog) {
+    public synchronized boolean indexChunkMarkers(String projectSlug, String catalog) {
         JSONArray items;
         try {
             items = new JSONArray(catalog);
         } catch (JSONException e) {
-            Logger.e(this.getClass().getName(), "Failed to parse the chunks catalog for " + projectSlug, e);
+            Logger.e(this.getClass().getName(), "Failed to parse the chunk marker catalog for " + projectSlug, e);
             return false;
         }
 
@@ -813,10 +817,10 @@ public class Indexer {
                 try {
                     JSONObject item = items.getJSONObject(i);
 
-                    mDatabaseHelper.addChunk(mDatabase, item.getString("chp"), item.getString("firstvs"), projectId);
+                    mDatabaseHelper.addChunkMarker(mDatabase, item.getString("chp"), item.getString("firstvs"), projectId);
                     mDatabase.yieldIfContendedSafely();
                 } catch (JSONException e) {
-                    Logger.w(this.getClass().getName(), "Failed to parse a chunk for " + projectSlug, e);
+                    Logger.w(this.getClass().getName(), "Failed to parse a chunk marker for " + projectSlug, e);
                 }
             }
         }

--- a/app/src/main/java/com/door43/translationstudio/core/Indexer.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Indexer.java
@@ -1291,11 +1291,21 @@ public class Indexer {
 
     public void setExpired() {
         mDatabase.execSQL("UPDATE `resource`"
-                + " SET `source_catalog_local_modified_at`=0,"
-                + " `translation_notes_catalog_local_modified_at`=0,"
-                + " `translation_words_catalog_local_modified_at`=0,"
-                + " `translation_word_assignments_catalog_local_modified_at`=0,"
-                + " `checking_questions_catalog_local_modified_at`=0"
+                        + " SET `source_catalog_local_modified_at`=0,"
+                        + " `translation_notes_catalog_local_modified_at`=0,"
+                        + " `translation_words_catalog_local_modified_at`=0,"
+                        + " `translation_word_assignments_catalog_local_modified_at`=0,"
+                        + " `checking_questions_catalog_local_modified_at`=0"
         );
+    }
+
+    /**
+     * This is a temporary method for injecting the chunk marker urls into the project table
+     *
+     * @return
+     * @deprecated you probably shouldn't use this method
+     */
+    public boolean manuallyInjectChunkMarkerUrls() {
+        return mDatabaseHelper.manuallyInjectChunkMarkerUrls(mDatabase);
     }
 }

--- a/app/src/main/java/com/door43/translationstudio/core/Indexer.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Indexer.java
@@ -792,6 +792,38 @@ public class Indexer {
     }
 
     /**
+     * Builds a chunks index from json
+     * @param projectSlug
+     * @param catalog
+     * @return
+     */
+    public synchronized boolean indexChunks(String projectSlug, String catalog) {
+        JSONArray items;
+        try {
+            items = new JSONArray(catalog);
+        } catch (JSONException e) {
+            Logger.e(this.getClass().getName(), "Failed to parse the chunks catalog for " + projectSlug, e);
+            return false;
+        }
+
+        long projectId = mDatabaseHelper.getProjectDBId(mDatabase, projectSlug);
+
+        if(projectId > 0) {
+            for (int i = 0; i < items.length(); i ++) {
+                try {
+                    JSONObject item = items.getJSONObject(i);
+
+                    mDatabaseHelper.addChunk(mDatabase, item.getString("chp"), item.getString("firstvs"), projectId);
+                    mDatabase.yieldIfContendedSafely();
+                } catch (JSONException e) {
+                    Logger.w(this.getClass().getName(), "Failed to parse a chunk for " + projectSlug, e);
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
      * Returns an array of projectS
      * @return
      */

--- a/app/src/main/java/com/door43/translationstudio/core/IndexerSQLiteHelper.java
+++ b/app/src/main/java/com/door43/translationstudio/core/IndexerSQLiteHelper.java
@@ -112,7 +112,9 @@ public class IndexerSQLiteHelper extends SQLiteOpenHelper{
                     "  `chunk_marker_catalog_server_modified_at` INTEGER NOT NULL DEFAULT 0," +
                     "  UNIQUE (`slug`)" +
                     ");");
-            db.execSQL("INSERT INTO `project_new` SELECT * FROM `project`;");
+            db.execSQL("INSERT INTO `project_new` (`id`, `slug`, `sort`, `modified_at`," +
+                    " `source_language_catalog_url`, `source_language_catalog_local_modified_at`," +
+                    " `source_language_catalog_server_modified_at`) SELECT * FROM `project`;");
             db.execSQL("DROP TABLE IF EXISTS `project`");
             db.execSQL("ALTER TABLE `project_new` RENAME TO `project`");
 
@@ -1167,13 +1169,17 @@ public class IndexerSQLiteHelper extends SQLiteOpenHelper{
      */
     public Project getProject(SQLiteDatabase db, String projectSlug, String sourceLanguageSlug) {
         Project project = null;
-        Cursor cursor = db.rawQuery("SELECT `p`.`sort`, `p`.`modified_at`, `p`.`source_language_catalog_url`,"
+        Cursor cursor = db.rawQuery("SELECT `p`.`sort`,"
+                + " `p`.`modified_at`,"
+                + " `p`.`source_language_catalog_url`,"
                 + " COALESCE(`sl1`.`slug`, `sl2`.`slug`, `sl3`.`slug`),"
                 + " COALESCE(`sl1`.`project_name`, `sl2`.`project_name`, `sl3`.`project_name`),"
                 + " COALESCE(`sl1`.`project_description`, `sl2`.`project_description`, `sl3`.`project_description`),"
-                + " `p`.`source_language_catalog_local_modified_at`, `p`.`source_language_catalog_server_modified_at`,"
+                + " `p`.`source_language_catalog_local_modified_at`,"
+                + " `p`.`source_language_catalog_server_modified_at`,"
                 + " `p`.`chunk_marker_catalog_url`,"
-                + " `p`.`chunk_marker_catalog_local_modified_at`, `p`.`chunk_marker_catalog_server_modified_at`"
+                + " `p`.`chunk_marker_catalog_local_modified_at`,"
+                + " `p`.`chunk_marker_catalog_server_modified_at`"
                 + " FROM `project` AS `p`"
                 + " LEFT JOIN `source_language` AS `sl1` ON `sl1`.`project_id`=`p`.`id`AND `sl1`.`slug`=?"
                 + " LEFT JOIN `source_language` AS `sl2` ON `sl2`.`project_id`=`p`.`id` AND `sl2`.`slug`='en'"
@@ -1184,15 +1190,15 @@ public class IndexerSQLiteHelper extends SQLiteOpenHelper{
             int sort = cursor.getInt(0);
             int dateModified = cursor.getInt(1);
             String sourceLanguageCatalog = cursor.getString(2);
-            String actualSsourceLanguageSlug = cursor.getString(3);
+            String actualSourceLanguageSlug = cursor.getString(3);
             String projectName = cursor.getString(4);
             String projectDescription = cursor.getString(5);
             int sourceLanguageCatalogLocalModified = cursor.getInt(6);
             int sourceLanguageCatalogServerModified = cursor.getInt(7);
-            String chunkMarkerCatalog = cursor.getString(9);
-            int chunkMarkerCatalogLocalModified = cursor.getInt(10);
-            int chunkMarkerCatalogServerModified = cursor.getInt(11);
-            project = new Project(projectSlug, actualSsourceLanguageSlug, projectName,
+            String chunkMarkerCatalog = cursor.getString(8);
+            int chunkMarkerCatalogLocalModified = cursor.getInt(9);
+            int chunkMarkerCatalogServerModified = cursor.getInt(10);
+            project = new Project(projectSlug, actualSourceLanguageSlug, projectName,
                     projectDescription, dateModified, sort, sourceLanguageCatalog,
                     sourceLanguageCatalogLocalModified, sourceLanguageCatalogServerModified,
                     chunkMarkerCatalog, chunkMarkerCatalogLocalModified, chunkMarkerCatalogServerModified);

--- a/app/src/main/java/com/door43/translationstudio/core/IndexerSQLiteHelper.java
+++ b/app/src/main/java/com/door43/translationstudio/core/IndexerSQLiteHelper.java
@@ -156,6 +156,7 @@ public class IndexerSQLiteHelper extends SQLiteOpenHelper{
 
     /**
      * Inserts or updates a project
+     * // TODO: 4/8/16 eventually this will take in the chunk marker catalog info
      * @param db
      * @param slug
      * @param sort

--- a/app/src/main/java/com/door43/translationstudio/core/IndexerSQLiteHelper.java
+++ b/app/src/main/java/com/door43/translationstudio/core/IndexerSQLiteHelper.java
@@ -322,11 +322,11 @@ public class IndexerSQLiteHelper extends SQLiteOpenHelper{
      */
     public void deleteSourceLanguage(SQLiteDatabase db, String sourceLanguageSlug, String projectSlug) {
         db.execSQL("DELETE FROM `source_language`"
-                   + " WHERE `id` IN ("
-                   + "  SELECT `sl`.`id` from `source_language` AS `sl`"
-                   + "  LEFT JOIN `project` AS `p` ON `p`.`id`=`sl`.`project_id`"
-                   + "  WHERE `sl`.`slug`=? AND `p`.`slug`=?"
-                   + " )", new String[]{sourceLanguageSlug, projectSlug});
+                + " WHERE `id` IN ("
+                + "  SELECT `sl`.`id` from `source_language` AS `sl`"
+                + "  LEFT JOIN `project` AS `p` ON `p`.`id`=`sl`.`project_id`"
+                + "  WHERE `sl`.`slug`=? AND `p`.`slug`=?"
+                + " )", new String[]{sourceLanguageSlug, projectSlug});
     }
 
     /**
@@ -2172,5 +2172,25 @@ public class IndexerSQLiteHelper extends SQLiteOpenHelper{
                 "`chunk_marker_catalog_url` = 'https://api.unfoldingword.org/bible/txt/1/' || `project`.`slug` || '/chunks.json'" +
                 "WHERE `project`.`slug` <> 'obs'");
         return true;
+    }
+
+    /**
+     * Returns an array of chunk markers for the project
+     * @param db
+     * @param projectSlug
+     * @return
+     */
+    public ChunkMarker[] getChunkMarkers(SQLiteDatabase db, String projectSlug) {
+        List<ChunkMarker> chunkMarkers = new ArrayList<>();
+        Cursor cursor = db.rawQuery("SELECT `cm`.`chapter_slug`, `cm`.`first_verse_slug` FROM `chunk_markers` AS `cm`"
+                + " LEFT JOIN `project` AS `p` ON `p`.`id` = `cm`.`project_id`"
+                + " WHERE `p`.`slug`=?", new String[]{projectSlug});
+        cursor.moveToFirst();
+        while(!cursor.isAfterLast()) {
+            chunkMarkers.add(new ChunkMarker(cursor.getString(0), cursor.getString(1)));
+            cursor.moveToNext();
+        }
+        cursor.close();
+        return chunkMarkers.toArray(new ChunkMarker[chunkMarkers.size()]);
     }
 }

--- a/app/src/main/java/com/door43/translationstudio/core/IndexerSQLiteHelper.java
+++ b/app/src/main/java/com/door43/translationstudio/core/IndexerSQLiteHelper.java
@@ -109,7 +109,7 @@ public class IndexerSQLiteHelper extends SQLiteOpenHelper{
                     "  `source_language_catalog_server_modified_at` INTEGER NOT NULL DEFAULT 0," +
                     "  `chunk_marker_catalog_url` TEXT NULL DEFAULT NULL," +
                     "  `chunk_marker_catalog_local_modified_at` INTEGER NOT NULL DEFAULT 0," +
-                    "  `chunk_marker_catalog_server_modified_at` INTEGER NOT NULL DEFAULT 0" +
+                    "  `chunk_marker_catalog_server_modified_at` INTEGER NOT NULL DEFAULT 0," +
                     "  UNIQUE (`slug`)" +
                     ");");
             db.execSQL("INSERT INTO `project_new` SELECT * FROM `project`;");

--- a/app/src/main/java/com/door43/translationstudio/core/IndexerSQLiteHelper.java
+++ b/app/src/main/java/com/door43/translationstudio/core/IndexerSQLiteHelper.java
@@ -2051,4 +2051,18 @@ public class IndexerSQLiteHelper extends SQLiteOpenHelper{
         cursor.close();
         return article;
     }
+
+    /**
+     * Adds a chunk
+     * 
+     * @param mDatabase
+     * @param chapter
+     * @param firstVerse
+     * @param projectId
+     * @return
+     */
+    public long addChunk(SQLiteDatabase mDatabase, String chapter, String firstVerse, long projectId) {
+        // TODO: 4/5/2016 impliment 
+        return 0;
+    }
 }

--- a/app/src/main/java/com/door43/translationstudio/core/Library.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Library.java
@@ -247,7 +247,7 @@ public class Library {
             success = false;
         }
         if(listener != null) {
-            listener.onProgress(1, 5);
+            listener.onProgress(1, 6);
         }
 
         // words
@@ -255,7 +255,7 @@ public class Library {
             mAppIndex.markWordsCatalogUpToDate(sourceTranslation);
         }
         if(listener != null) {
-            listener.onProgress(2, 5);
+            listener.onProgress(2, 6);
         }
 
         // word assignments
@@ -263,7 +263,7 @@ public class Library {
             mAppIndex.markWordAssignmentsCatalogUpToDate(sourceTranslation);
         }
         if(listener != null) {
-            listener.onProgress(3, 5);
+            listener.onProgress(3, 6);
         }
 
         // notes
@@ -271,7 +271,7 @@ public class Library {
             mAppIndex.markNotesCatalogUpToDate(sourceTranslation);
         }
         if(listener != null) {
-            listener.onProgress(4, 5);
+            listener.onProgress(4, 6);
         }
 
         // questions
@@ -279,8 +279,20 @@ public class Library {
             mAppIndex.markQuestionsCatalogUpToDate(sourceTranslation);
         }
         if(listener != null) {
-            listener.onProgress(5, 5);
+            listener.onProgress(5, 6);
         }
+
+        // chunks
+        if(mDownloader.downloadChunks(sourceTranslation.projectSlug, mAppIndex)) {
+            mAppIndex.markChunksCatalogUpToDate(sourceTranslation);
+        }
+
+        if(listener != null) {
+            listener.onProgress(6, 6);
+        }
+
+        // TODO: 4/5/2016 eventually ta
+
 
         // Images are not downloaded here; rather, fetched on demand since they're large.
 

--- a/app/src/main/java/com/door43/translationstudio/core/Library.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Library.java
@@ -985,7 +985,12 @@ public class Library {
      */
     public boolean manuallyInjectChunkMarkerCatalogUrl() {
         getActiveIndex().beginTransaction();
-        boolean success = getActiveIndex().manuallyInjectChunkMarkerUrls();
+        boolean success = false;
+        try {
+            success = getActiveIndex().manuallyInjectChunkMarkerUrls();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
         getActiveIndex().endTransaction(success);
         return success;
     }

--- a/app/src/main/java/com/door43/translationstudio/core/Library.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Library.java
@@ -10,7 +10,6 @@ import com.door43.util.Zip;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -19,8 +18,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-
-import javax.xml.transform.Source;
 
 /**
  * Created by joel on 8/29/2015.
@@ -112,6 +109,14 @@ public class Library {
     }
 
     /**
+     * Downloads the chunk markers for this project from the server
+     * @param projectSlug
+     */
+    private void downloadChunkMarkerList(String projectSlug) {
+        mDownloader.downloadChunkMarkerList(projectSlug, mAppIndex);
+    }
+
+    /**
      * Downloads the source language catalog from the server
      * @param projectId
      */
@@ -134,6 +139,7 @@ public class Library {
             String[] projectIds = mAppIndex.getProjectSlugs();
             for (int i = 0; i < projectIds.length; i ++) {
                 String projectId = projectIds[i];
+                downloadChunkMarkerList(projectId);
                 downloadSourceLanguageList(projectId);
                 if(listener != null) {
                     if(!listener.onProgress((i + 1), projectIds.length)) {
@@ -280,11 +286,6 @@ public class Library {
         }
         if(listener != null) {
             listener.onProgress(5, 6);
-        }
-
-        // chunks
-        if(mDownloader.downloadChunks(sourceTranslation.projectSlug, mAppIndex)) {
-            mAppIndex.markChunksCatalogUpToDate(sourceTranslation);
         }
 
         if(listener != null) {

--- a/app/src/main/java/com/door43/translationstudio/core/Library.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Library.java
@@ -978,6 +978,19 @@ public class Library {
     }
 
     /**
+     * This is a temporary method so we can index chunk markers
+     * Chunk markers are not currently available in the api so we must inject the catalog urls manually
+     * @return
+     * @deprecated you probably shouldn't use this method
+     */
+    public boolean manuallyInjectChunkMarkerCatalogUrl() {
+        getActiveIndex().beginTransaction();
+        boolean success = getActiveIndex().manuallyInjectChunkMarkerUrls();
+        getActiveIndex().endTransaction(success);
+        return success;
+    }
+
+    /**
      * Resets all the date_modified values
      */
     public void setExpired() {

--- a/app/src/main/java/com/door43/translationstudio/core/Library.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Library.java
@@ -182,6 +182,15 @@ public class Library {
     }
 
     /**
+     * Returns an array of chunk markers for the project
+     * @param projectSlug
+     * @return
+     */
+    public ChunkMarker[] getChunkMarkers(String projectSlug) {
+        return mAppIndex.getChunkMarkers(projectSlug);
+    }
+
+    /**
      * Downloads all of the projects from the server
      *
      * @param projectProgressListener

--- a/app/src/main/java/com/door43/translationstudio/core/Project.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Project.java
@@ -12,10 +12,13 @@ public class Project {
     public final String name;
     public final String sourceLanguageId;
     public final int sort;
-    public final String sourceLanguageCatalog;
     private String mId;
+    public final String sourceLanguageCatalog;
     public final int sourceLanguageCatalogLocalDateModified;
     public final int sourceLanguageCatalogServerDateModified;
+    public final String chunkMarkerCatalog;
+    public final int chunkMarkerCatalogLocalDateModified;
+    public final int chunkMarkerCatalogServerDateModified;
 
     /**
      * @param projectId The id of the project
@@ -23,10 +26,13 @@ public class Project {
      * @param name the name of the project
      * @param description the description of the project
      * @param dateModified the date the project was last modified
+     * @param sourceLanguageCatalog
      * @param sourceLanguageCatalogLocalDateModified
      * @param sourceLanguageCatalogServerDateModified
      */
-    public Project(String projectId, String sourceLanguageId, String name, String description, int dateModified, int sort, String sourceLanguageCatalog, int sourceLanguageCatalogLocalDateModified, int sourceLanguageCatalogServerDateModified) {
+    public Project(String projectId, String sourceLanguageId, String name, String description, int dateModified, int sort,
+                   String sourceLanguageCatalog, int sourceLanguageCatalogLocalDateModified, int sourceLanguageCatalogServerDateModified,
+                   String chunkMarkerCatalog, int chunkMarkerCatalogLocalDateModified, int chunkMarkerCatalogServerDateModified) {
         mId = projectId;
         this.name = name;
         this.description = description;
@@ -36,6 +42,9 @@ public class Project {
         this.sort = sort;
         this.sourceLanguageCatalogLocalDateModified = sourceLanguageCatalogLocalDateModified;
         this.sourceLanguageCatalogServerDateModified = sourceLanguageCatalogServerDateModified;
+        this.chunkMarkerCatalog = chunkMarkerCatalog;
+        this.chunkMarkerCatalogLocalDateModified = chunkMarkerCatalogLocalDateModified;
+        this.chunkMarkerCatalogServerDateModified = chunkMarkerCatalogServerDateModified;
     }
 
     /**
@@ -62,8 +71,8 @@ public class Project {
             String sourceLanguageCatalog = json.getString("lang_catalog");
             int sourceLanguageServerModified = Util.getDateFromUrl(sourceLanguageCatalog);
             int sort = json.getInt("sort");
-
-            return new Project(projectId, sourceLanguageId, name, description, dateModified, sort, sourceLanguageCatalog, 0, sourceLanguageServerModified);
+            // TODO: 4/7/16 eventually we'll grab the chunks info
+            return new Project(projectId, sourceLanguageId, name, description, dateModified, sort, sourceLanguageCatalog, 0, sourceLanguageServerModified, "", 0, 0);
         }
         return null;
     }
@@ -81,8 +90,8 @@ public class Project {
             int sort = json.getInt("sort");
             String sourceLanguageCatalog = json.getString("lang_catalog");
             int sourceLanguageServerModified = Util.getDateFromUrl(sourceLanguageCatalog);
-
-            return new Project(projectId, null, null, null, dateModified, sort, sourceLanguageCatalog, 0, sourceLanguageServerModified);
+            // TODO: 4/7/16 eventually we'll grab the chunks info
+            return new Project(projectId, null, null, null, dateModified, sort, sourceLanguageCatalog, 0, sourceLanguageServerModified, "", 0, 0);
         }
         return null;
     }

--- a/app/src/main/java/com/door43/translationstudio/core/Resource.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Resource.java
@@ -28,6 +28,10 @@ public class Resource {
     private final int wordsServerDateModified;
     private final int wordAssignmentsServerDateModified;
     private final int questionsServerDateModified;
+    private final String chunksCatalogUrl;
+    private final int chunksDateModified;
+    private final int chunksServerDateModified;
+
     private long DBId = -1;
     private boolean isDownloaded;
     // TODO: 12/14/2015 hook these up
@@ -68,6 +72,11 @@ public class Resource {
         this.questionsCatalogUrl = questionsCatalogUrl;
         this.questionsDateModified = questionsDateModified;
         this.questionsServerDateModified = questionsServerDateModified;
+
+        // TODO: 4/5/2016 eventually these will be passed in
+        this.chunksCatalogUrl = "";
+        this.chunksDateModified = 0;
+        this.chunksServerDateModified = 0;
     }
 
     /**
@@ -312,4 +321,15 @@ public class Resource {
         return this.sourceLanguageDBId;
     }
 
+    public String getChunksCatalogUrl() {
+        return chunksCatalogUrl;
+    }
+
+    public int getChunksDateModified() {
+        return chunksDateModified;
+    }
+
+    public int getChunksServerDateModified() {
+        return chunksServerDateModified;
+    }
 }

--- a/app/src/main/java/com/door43/translationstudio/service/BackupService.java
+++ b/app/src/main/java/com/door43/translationstudio/service/BackupService.java
@@ -51,6 +51,7 @@ public class BackupService extends Service {
         int backupIntervalMinutes = Integer.parseInt(pref.getString(SettingsActivity.KEY_PREF_BACKUP_INTERVAL, getResources().getString(R.string.pref_default_backup_interval)));
         if(backupIntervalMinutes > 0) {
             int backupInterval = backupIntervalMinutes * 60 * 1000;
+            int delay = 60 * 1000; // wait a minute for the app to finish booting
             Logger.i(this.getClass().getName(), "Backups running every " + backupIntervalMinutes + " minute/s");
             sRunning = true;
             sTimer.scheduleAtFixedRate(new TimerTask() {
@@ -58,7 +59,7 @@ public class BackupService extends Service {
                 public void run() {
                     runBackup();
                 }
-            }, 0, backupInterval);
+            }, delay, backupInterval);
             return START_STICKY;
         } else {
             Logger.i(this.getClass().getName(), "Backups are disabled");

--- a/app/src/main/java/com/door43/translationstudio/tasks/GetLibraryUpdatesTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/GetLibraryUpdatesTask.java
@@ -37,7 +37,6 @@ public class GetLibraryUpdatesTask extends ManagedTask {
                 AppContext.setLastCheckedForUpdates(System.currentTimeMillis());
             }
         }
-
         // make sure we have the most recent target languages
         library.downloadTargetLanguages();
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -665,4 +665,5 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
     <string name="invalidate_keys_description" translatable="false">Sets keys invalid for auth testing</string>
     <string name="person_agrees_with_licenses">This person has agreed to the License Agreement, Statement of Faith, and Translation Guidelines</string>
     <string name="error_importing_unsupported_target_translation">The  translation of <xliff:g example="Open Bible Stories" id="project_name">%1$s</xliff:g> into <xliff:g example="Afaraf" id="language_name">%2$s</xliff:g> was created by a different version of <xliff:g example="translationStudio" id="app_name">%3$s</xliff:g> and cannot be opened. Please update your app and try again.</string>
+    <string name="version">Version</string>
 </resources>

--- a/app/src/main/res/xml/advanced_preferences.xml
+++ b/app/src/main/res/xml/advanced_preferences.xml
@@ -23,6 +23,12 @@
         android:negativeButtonText="@null"
         android:positiveButtonText="@null" />
 
+    <!-- TODO: eventually we'll use this to enable the developer settings by tapping on it several times-->
+    <!--<Preference-->
+        <!--android:key="app_version"-->
+        <!--android:title="@string/version"-->
+        <!--android:defaultValue="0.0.0" />-->
+
     <Preference android:title="@string/pref_title_developer_tools">
         <intent android:action="com.activity.DeveloperToolsActivity" />
     </Preference>


### PR DESCRIPTION
Fixes #1421 .

Changes in this pull request:
- Updated the db schema to support storing chunk markers
- Added developer tool to manually inject the chunk catalog urls (since it's not available in the api yet)
- Added support for indexing chunk catalogs.
- Added method to library for retrieving project chunk markers.

Chunk markers can be retrieved from the library like so:
```
ChunkMarker[] markers = Library.getChunkMarkers(projectSlug);
```

The `ChunkMarker` class contains public final properties `chapterSlug` and `firstVerseSlug`.

> NOTE: Once the chunks are added to the main catalog in the api we'll need to make some small changes to read it directly from the api.