### PR TITLE
Fix #1196 chapter titles, references, and project titles need to be validated during the publishing process

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
@@ -130,6 +130,17 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
         listItems.add(projectTitleItem);
 
         for(Chapter c:chapters) {
+            // put in map for easier retrieval
+            mChapters.put(c.getId(), c);
+
+            String[] chapterFrameSlugs = mLibrary.getFrameSlugs(mSourceTranslation, c.getId());
+            boolean setStartPosition = startingChapterSlug != null && c.getId().equals(startingChapterSlug) && chapterFrameSlugs.length > 0;
+
+            // default starting selection is first item in chapter
+            if(setStartPosition) {
+                setListStartPosition(listItems.size());
+            }
+
             // add title and reference cards for chapter
             if(!c.title.isEmpty()) {
                 ListItem item = new ListItem(null, c.getId());
@@ -141,15 +152,8 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                 item.isChapterReference = true;
                 listItems.add(item);
             }
-            // put in map for easier retrieval
-            mChapters.put(c.getId(), c);
 
-            String[] chapterFrameSlugs = mLibrary.getFrameSlugs(mSourceTranslation, c.getId());
-            boolean setStartPosition = startingChapterSlug != null && c.getId().equals(startingChapterSlug) && chapterFrameSlugs.length > 0;
-                // identify starting selection
-            if(setStartPosition) {
-                setListStartPosition(listItems.size());
-            }
+            // identify starting frame selection
             for(String frameSlug:chapterFrameSlugs) {
                 if(setStartPosition && startingFrameSlug != null && frameSlug.equals(startingFrameSlug)) {
                     setListStartPosition(listItems.size());

--- a/app/src/main/java/com/door43/translationstudio/tasks/ValidationTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/ValidationTask.java
@@ -1,6 +1,7 @@
 package com.door43.translationstudio.tasks;
 
 import com.door43.translationstudio.core.Chapter;
+import com.door43.translationstudio.core.ChapterTranslation;
 import com.door43.translationstudio.core.Frame;
 import com.door43.translationstudio.core.FrameTranslation;
 import com.door43.translationstudio.core.Library;
@@ -55,19 +56,31 @@ public class ValidationTask extends ManagedTask {
             boolean isFinished = projectTranslation.isTitleFinished();
             if(!isFinished) {
                 mValidations.add(ValidationItem.generateInvalidGroup(projectTitle, sourceLanguage));
-                mValidations.add(ValidationItem.generateInvalidFrame(projectTitle, sourceLanguage, projectTranslation.getTitle(), targetLanguage, TranslationFormat.DEFAULT, mTargetTranslationId, "1", "1"));
+                mValidations.add(ValidationItem.generateInvalidFrame(projectTitle, sourceLanguage, projectTranslation.getTitle(), targetLanguage, TranslationFormat.DEFAULT, mTargetTranslationId, "0", "0"));
             }
         }
 
         for(int i = 0; i < chapters.length; i ++) {
             Chapter chapter = chapters[i];
-            // TODO: validate title and reference
+
             Frame[] frames = library.getFrames(sourceTranslation, chapter.getId());
 
             // validate frames
             int lastValidFrameIndex = -1;
             boolean chapterIsValid = true;
             List<ValidationItem> frameValidations = new ArrayList<>();
+
+            ChapterTranslation chapterTranslation = targetTranslation.getChapterTranslation(chapter.getId());
+            if((chapter.title != null)  && !chapterTranslation.isTitleFinished()) {
+                chapterIsValid = false;
+                frameValidations.add(ValidationItem.generateInvalidFrame(chapter.title, sourceLanguage, chapterTranslation.title, targetLanguage, TranslationFormat.DEFAULT, mTargetTranslationId, chapter.getId(), "00"));
+            }
+
+            if((chapter.reference != null) && !chapterTranslation.isReferenceFinished()) {
+                chapterIsValid = false;
+                frameValidations.add(ValidationItem.generateInvalidFrame(chapter.reference, sourceLanguage, chapterTranslation.reference, targetLanguage, TranslationFormat.DEFAULT, mTargetTranslationId, chapter.getId(), "00"));
+            }
+
             for(int j = 0; j < frames.length; j ++) {
                 Frame frame = frames[j];
                 FrameTranslation frameTranslation = targetTranslation.getFrameTranslation(frame);

--- a/app/src/main/java/com/door43/translationstudio/tasks/ValidationTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/ValidationTask.java
@@ -71,12 +71,12 @@ public class ValidationTask extends ManagedTask {
             List<ValidationItem> frameValidations = new ArrayList<>();
 
             ChapterTranslation chapterTranslation = targetTranslation.getChapterTranslation(chapter.getId());
-            if((chapter.title != null)  && !chapterTranslation.isTitleFinished()) {
+            if((chapter.title != null) && (!chapter.title.isEmpty()) && !chapterTranslation.isTitleFinished()) {
                 chapterIsValid = false;
                 frameValidations.add(ValidationItem.generateInvalidFrame(chapter.title, sourceLanguage, chapterTranslation.title, targetLanguage, TranslationFormat.DEFAULT, mTargetTranslationId, chapter.getId(), "00"));
             }
 
-            if((chapter.reference != null) && !chapterTranslation.isReferenceFinished()) {
+            if((chapter.reference != null) && (!chapter.reference.isEmpty()) && !chapterTranslation.isReferenceFinished()) {
                 chapterIsValid = false;
                 frameValidations.add(ValidationItem.generateInvalidFrame(chapter.reference, sourceLanguage, chapterTranslation.reference, targetLanguage, TranslationFormat.DEFAULT, mTargetTranslationId, chapter.getId(), "00"));
             }

--- a/app/src/main/java/com/door43/translationstudio/tasks/ValidationTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/ValidationTask.java
@@ -4,10 +4,12 @@ import com.door43.translationstudio.core.Chapter;
 import com.door43.translationstudio.core.Frame;
 import com.door43.translationstudio.core.FrameTranslation;
 import com.door43.translationstudio.core.Library;
+import com.door43.translationstudio.core.ProjectTranslation;
 import com.door43.translationstudio.core.SourceLanguage;
 import com.door43.translationstudio.core.SourceTranslation;
 import com.door43.translationstudio.core.TargetLanguage;
 import com.door43.translationstudio.core.TargetTranslation;
+import com.door43.translationstudio.core.TranslationFormat;
 import com.door43.translationstudio.core.Translator;
 import com.door43.translationstudio.newui.publish.ValidationItem;
 import com.door43.translationstudio.AppContext;
@@ -45,6 +47,18 @@ public class ValidationTask extends ManagedTask {
         // validate chapters
         int lastValidChapterIndex = -1;
         List<ValidationItem> chapterValidations = new ArrayList<>();
+
+        //check for project title
+        String projectTitle = sourceTranslation.getProjectTitle();
+        if(projectTitle != null) {
+            ProjectTranslation projectTranslation = targetTranslation.getProjectTranslation();
+            boolean isFinished = projectTranslation.isTitleFinished();
+            if(!isFinished) {
+                mValidations.add(ValidationItem.generateInvalidGroup(projectTitle, sourceLanguage));
+                mValidations.add(ValidationItem.generateInvalidFrame(projectTitle, sourceLanguage, projectTranslation.getTitle(), targetLanguage, TranslationFormat.DEFAULT, mTargetTranslationId, "1", "1"));
+            }
+        }
+
         for(int i = 0; i < chapters.length; i ++) {
             Chapter chapter = chapters[i];
             // TODO: validate title and reference


### PR DESCRIPTION
Fix #1196 chapter titles, references, and project titles need to be validated during the publishing process.

Added titles and references to the ValidationTask.  Modified ReviewModeAdapter so that if matching frame slug is not found, it defaults starting position to first card in chapter.  This allows us to scroll to show chapter title and references.