### PR TITLE
Fixes #1473 Formatting being lost.

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/rendering/USFMRenderer.java
+++ b/app/src/main/java/com/door43/translationstudio/rendering/USFMRenderer.java
@@ -90,8 +90,7 @@ public class USFMRenderer extends ClickableRenderingEngine {
         CharSequence out = in;
 
         out = trimWhitespace(out);
-        out = renderLineBreaks(out);
-        // TODO: this will strip out new lines. Eventually we may want to convert these to paragraphs.
+//        out = renderLineBreaks(out);  // TODO: Eventually we may want to convert these to paragraphs.
         out = renderWhiteSpace(out);
         out = renderMajorSectionHeading(out);
         out = renderSectionHeading(out);

--- a/app/src/main/java/com/door43/translationstudio/rendering/USXRenderer.java
+++ b/app/src/main/java/com/door43/translationstudio/rendering/USXRenderer.java
@@ -90,8 +90,7 @@ public class USXRenderer extends ClickableRenderingEngine {
         CharSequence out = in;
 
         out = trimWhitespace(out);
-        out = renderLineBreaks(out);
-        // TODO: this will strip out new lines. Eventually we may want to convert these to paragraphs.
+//        out = renderLineBreaks(out); // TODO: Eventually we may want to convert these to paragraphs.
         out = renderWhiteSpace(out);
         out = renderMajorSectionHeading(out);
         out = renderSectionHeading(out);


### PR DESCRIPTION
Fixes #1473 Formatting being lost.

Took out section of code that is removing linefeeds for both USX and USFM renderers.

@neutrinog - this seems to fix the linefeeds being stripped out.  Did you have more in mind?