### PR TITLE
Fix #355 associate tstudio with app

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/core/Translator.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Translator.java
@@ -317,16 +317,26 @@ public class Translator {
         return t;
     }
 
-     /**
+    /**
      * Imports a tstudio archive
      * @param file
      * @return an array of target translation slugs that were successfully imported
      */
     public String[] importArchive(File file) throws Exception {
+        return importArchive( file, false);
+    }
+
+   /**
+    * Imports a tstudio archive
+    * @param file
+    * @param overwrite - if true then local changes are clobbered
+    * @return an array of target translation slugs that were successfully imported
+    */
+    public String[] importArchive(File file, boolean overwrite) throws Exception {
         FileInputStream in = null;
         try {
             in = new FileInputStream(file);
-            return importArchive(in);
+            return importArchive(in, overwrite);
         } catch (Exception e) {
             throw e;
         } finally {
@@ -340,44 +350,22 @@ public class Translator {
      * @return an array of target translation slugs that were successfully imported
      */
     public String[] importArchive(InputStream in) throws Exception {
-        File archiveDir = new File(getLocalCacheDir(), System.currentTimeMillis()+"");
-        List<String> importedSlugs = new ArrayList<>();
+        return importArchive( in, false);
+    }
+
+    /**
+     * Imports a tstudio archive from an input stream
+     * @param in
+     * @param overwrite - if true then local changes are clobbered
+     * @return an array of target translation slugs that were successfully imported
+     */
+    public String[] importArchive(InputStream in, boolean overwrite) throws Exception {
+        String[] importedSlugs = {};
+        File archiveDir = null;
         try {
-            archiveDir.mkdirs();
-            Zip.unzipFromStream(in, archiveDir);
-
+            archiveDir = unpackArchive(in);
             File[] targetTranslationDirs = ArchiveImporter.importArchive(archiveDir);
-            for(File newDir:targetTranslationDirs) {
-                TargetTranslation newTargetTranslation = TargetTranslation.open(newDir);
-                if(newTargetTranslation != null) {
-                    // TRICKY: the correct id is pulled from the manifest to avoid propogating bad folder names
-                    String targetTranslationId = newTargetTranslation.getId();
-                    File localDir = new File(mRootDir, targetTranslationId);
-                    TargetTranslation localTargetTranslation = TargetTranslation.open(localDir);
-                    if(localTargetTranslation != null) {
-                        // commit local changes to history
-                        if(localTargetTranslation != null) {
-                            localTargetTranslation.commitSync();
-                        }
-
-                        // merge translations
-                        try {
-                            localTargetTranslation.merge(newDir);
-                        } catch(Exception e) {
-                            e.printStackTrace();
-                            continue;
-                        }
-                    }  else {
-                        // import new translation
-                        FileUtilities.safeDelete(localDir); // in case local was an invalid target translation
-                        FileUtils.moveDirectory(newDir, localDir);
-                    }
-                    // update the generator info. TRICKY: we re-open to get the updated manifest.
-                    TargetTranslation.updateGenerator(mContext, TargetTranslation.open(localDir));
-
-                    importedSlugs.add(targetTranslationId);
-                }
-            }
+            importTargetTranslationDirs(targetTranslationDirs, overwrite);
         } catch (Exception e) {
             throw e;
         } finally {
@@ -385,7 +373,108 @@ public class Translator {
             FileUtils.deleteQuietly(archiveDir);
         }
 
+        return importedSlugs;
+    }
+
+    /**
+     * do importing
+     * @param targetTranslationDirs
+     * @param overwrite
+     * @return
+     * @throws Exception
+     */
+    public String[] importTargetTranslationDirs(File[] targetTranslationDirs, boolean overwrite) throws Exception {
+        List<String> importedSlugs = new ArrayList<>();
+        for(File newDir:targetTranslationDirs) {
+            TargetTranslation newTargetTranslation = TargetTranslation.open(newDir);
+            if(newTargetTranslation != null) {
+                // TRICKY: the correct id is pulled from the manifest to avoid propagating bad folder names
+                String targetTranslationId = newTargetTranslation.getId();
+                File localDir = new File(mRootDir, targetTranslationId);
+                TargetTranslation localTargetTranslation = TargetTranslation.open(localDir);
+                if((localTargetTranslation != null) && !overwrite) {
+                    // commit local changes to history
+                    if(localTargetTranslation != null) {
+                        localTargetTranslation.commitSync();
+                    }
+
+                    // merge translations
+                    try {
+                        localTargetTranslation.merge(newDir);
+                    } catch(Exception e) {
+                        e.printStackTrace();
+                        continue;
+                    }
+                }  else {
+                    // import new translation
+                    FileUtilities.safeDelete(localDir); // in case local was an invalid target translation
+                    FileUtils.moveDirectory(newDir, localDir);
+                }
+                // update the generator info. TRICKY: we re-open to get the updated manifest.
+                TargetTranslation.updateGenerator(mContext, TargetTranslation.open(localDir));
+
+                importedSlugs.add(targetTranslationId);
+            }
+        }
         return importedSlugs.toArray(new String[importedSlugs.size()]);
+    }
+
+    /**
+     * Imports a tstudio archive
+     * @param file
+     * @return an array of target translation slugs that were successfully imported
+     */
+    public File unpackArchive(File file) throws Exception {
+        FileInputStream in = null;
+        try {
+            in = new FileInputStream(file);
+            return unpackArchive(in);
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            IOUtils.closeQuietly(in);
+        }
+    }
+
+    /**
+     * Unpacks a tstudio archive from an input stream
+     * @param in
+     * @return an array of target translation slugs that were successfully imported
+     */
+    public File unpackArchive(InputStream in) throws Exception {
+        File archiveDir = new File(getLocalCacheDir(), System.currentTimeMillis()+"");
+        try {
+            archiveDir.mkdirs();
+            Zip.unzipFromStream(in, archiveDir);
+            return archiveDir;
+        } catch (Exception e) {
+            FileUtils.deleteQuietly(archiveDir);
+            throw e;
+        } finally {
+            IOUtils.closeQuietly(in);
+        }
+    }
+
+    /**
+     * checks imported target translations to see if we already have a similar project
+     * @param targetTranslationDirs
+     * @return
+     * @throws Exception
+     */
+    public boolean isExistingProject(File[] targetTranslationDirs) throws Exception {
+        for (File newDir : targetTranslationDirs) {
+            TargetTranslation newTargetTranslation = TargetTranslation.open(newDir);
+            if (newTargetTranslation != null) {
+                // TRICKY: the correct id is pulled from the manifest to avoid propagating bad folder names
+                String targetTranslationId = newTargetTranslation.getId();
+                File localDir = new File(mRootDir, targetTranslationId);
+                TargetTranslation localTargetTranslation = TargetTranslation.open(localDir);
+                if ((localTargetTranslation != null)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/app/src/main/java/com/door43/translationstudio/core/Translator.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Translator.java
@@ -318,7 +318,7 @@ public class Translator {
     }
 
     /**
-     * Imports a tstudio archive
+     * Imports a tstudio archive, uses default of merge, not overwrite
      * @param file
      * @return an array of target translation slugs that were successfully imported
      */
@@ -345,7 +345,7 @@ public class Translator {
     }
 
     /**
-     * Imports a tstudio archive from an input stream
+     * Imports a tstudio archive from an input stream, uses default of merge, not overwrite
      * @param in
      * @return an array of target translation slugs that were successfully imported
      */

--- a/app/src/main/java/com/door43/translationstudio/newui/home/HomeActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/home/HomeActivity.java
@@ -222,7 +222,9 @@ public class HomeActivity extends BaseActivity implements GenericTaskWatcher.OnF
             hand.post(new Runnable() {
                 @Override
                 public void run() {
-                    showImportResults(mExamineTask.mContentUri.toString(), mExamineTask.mProjectsFound, importTask.mSuccess);
+                    String[] importedSlugs = importTask.getImportedSlugs();
+                    boolean success = (importedSlugs != null) && (importedSlugs.length > 0);
+                    showImportResults(mExamineTask.mContentUri.toString(), mExamineTask.mProjectsFound, success);
                 }
             });
             mExamineTask.cleanup();

--- a/app/src/main/java/com/door43/translationstudio/tasks/ExamineImportsForCollisionsTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/ExamineImportsForCollisionsTask.java
@@ -1,0 +1,77 @@
+package com.door43.translationstudio.tasks;
+
+import android.content.ContentResolver;
+import android.net.Uri;
+
+import com.door43.tools.reporting.Logger;
+import com.door43.translationstudio.AppContext;
+import com.door43.translationstudio.core.ArchiveDetails;
+import com.door43.translationstudio.core.TargetTranslation;
+import com.door43.translationstudio.core.Translator;
+import com.door43.util.tasks.ManagedTask;
+
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.util.Locale;
+
+/**
+ * Created by blm on 5/13/16.
+ */
+
+public class ExamineImportsForCollisionsTask extends ManagedTask {
+
+    public static final String TASK_ID = "search_imports_for_collisions_task";
+    public static final String TAG = ExamineImportsForCollisionsTask.class.getSimpleName();
+
+    public boolean mSuccess;
+    private ContentResolver resolver;
+    public Uri mContentUri;
+    public File mProjectsFolder;
+    public boolean mAlreadyPresent;
+    public String mProjectsFound;
+
+    /**
+     *
+     */
+    public ExamineImportsForCollisionsTask(ContentResolver resolver, Uri mContentUri) {
+        mSuccess = false;
+        mAlreadyPresent = false;
+        this.resolver = resolver;
+        this.mContentUri = mContentUri;
+    }
+
+    public void cleanup() {
+        if(mProjectsFolder != null) {
+            FileUtils.deleteQuietly(mProjectsFolder);
+        }
+        mProjectsFolder = null;
+    }
+
+    @Override
+    public void start() {
+        mSuccess = false;
+        try {
+            mProjectsFolder = File.createTempFile("targettranslation", "." + Translator.ARCHIVE_EXTENSION);
+            FileUtils.copyInputStreamToFile(resolver.openInputStream(mContentUri), mProjectsFolder);
+            ArchiveDetails details = ArchiveDetails.newInstance(mProjectsFolder, Locale.getDefault().getLanguage(), AppContext.getLibrary());
+            mProjectsFound = "";
+            mAlreadyPresent = false;
+            for (ArchiveDetails.TargetTranslationDetails td : details.targetTranslationDetails) {
+                mProjectsFound += td.projectName + " - " + td.targetLanguageName + ", ";
+
+                String targetTranslationId = td.targetTranslationSlug;
+                File localDir = new File(AppContext.getTranslator().getPath(), targetTranslationId);
+                TargetTranslation localTargetTranslation = TargetTranslation.open(localDir);
+                if ((localTargetTranslation != null)) {
+                    mAlreadyPresent = true;
+                }
+            }
+            mProjectsFound = mProjectsFound.replaceAll(", $", "");
+            mSuccess = true;
+        } catch (Exception e) {
+            Logger.e(TAG,"Error processing input file: " + mContentUri.toString());
+        }
+    }
+}
+

--- a/app/src/main/java/com/door43/translationstudio/tasks/ExamineImportsForCollisionsTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/ExamineImportsForCollisionsTask.java
@@ -61,8 +61,7 @@ public class ExamineImportsForCollisionsTask extends ManagedTask {
                 mProjectsFound += td.projectName + " - " + td.targetLanguageName + ", ";
 
                 String targetTranslationId = td.targetTranslationSlug;
-                File localDir = new File(AppContext.getTranslator().getPath(), targetTranslationId);
-                TargetTranslation localTargetTranslation = TargetTranslation.open(localDir);
+                TargetTranslation localTargetTranslation = AppContext.getTranslator().getTargetTranslation(targetTranslationId);
                 if ((localTargetTranslation != null)) {
                     mAlreadyPresent = true;
                 }

--- a/app/src/main/java/com/door43/translationstudio/tasks/ImportProjectsTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/ImportProjectsTask.java
@@ -1,0 +1,36 @@
+package com.door43.translationstudio.tasks;
+
+import com.door43.translationstudio.AppContext;
+import com.door43.util.tasks.ManagedTask;
+
+import java.io.File;
+
+/**
+ * Created by blm on 5/17/16.
+ */
+public class ImportProjectsTask extends ManagedTask {
+
+    public static final String TASK_ID = "imports_projects_task";
+
+    private File projectsFolder;
+    private boolean overwrite;
+    public boolean mSuccess;
+
+    public ImportProjectsTask(File projectsFolder, boolean overwrite) {
+        this.projectsFolder = projectsFolder;
+        this.overwrite = overwrite;
+        mSuccess = false;
+    }
+
+    @Override
+    public void start() {
+        mSuccess = false;
+
+        try {
+            String[] importedSlugs = AppContext.getTranslator().importArchive(projectsFolder, overwrite);
+            mSuccess = (importedSlugs.length > 0);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/app/src/main/java/com/door43/translationstudio/tasks/ImportProjectsTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/ImportProjectsTask.java
@@ -14,23 +14,23 @@ public class ImportProjectsTask extends ManagedTask {
 
     private File projectsFolder;
     private boolean overwrite;
-    public boolean mSuccess;
+    private String[] importedSlugs;
 
     public ImportProjectsTask(File projectsFolder, boolean overwrite) {
         this.projectsFolder = projectsFolder;
         this.overwrite = overwrite;
-        mSuccess = false;
     }
 
     @Override
     public void start() {
-        mSuccess = false;
-
         try {
-            String[] importedSlugs = AppContext.getTranslator().importArchive(projectsFolder, overwrite);
-            mSuccess = (importedSlugs.length > 0);
+            importedSlugs = AppContext.getTranslator().importArchive(projectsFolder, overwrite);
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    public String[] getImportedSlugs() {
+        return importedSlugs;
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -743,4 +743,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
     <string name="no_chunk_list">No chunk list found for \'<xliff:g example="marc" id="book_name">%1$s</xliff:g>\'</string>
     <string name="chapter_count_invalid">Expected <xliff:g example="16" id="chunk_count">%1$s</xliff:g> chapters, but last chapter was <xliff:g example="15" id="chapter_count">%2$s</xliff:g></string>
     <string name="label_restore">Restore</string>
+    <string name="title_import_Success">Import Success</string>
+    <string name="title_import_Failed">Import Failed!</string>
+    <string name="import_project_success">Success Importing <xliff:g example="Mark" id="project">%1$s</xliff:g> from:\n<xliff:g example="/downloads/file.tx" id="path">%2$s</xliff:g></string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -741,4 +741,5 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
     <string name="could_not_parse">Could not parse \'<xliff:g example="Mark.usfm" id="file_name">%1$s</xliff:g>\'</string>
     <string name="no_chunk_list">No chunk list found for \'<xliff:g example="marc" id="book_name">%1$s</xliff:g>\'</string>
     <string name="chapter_count_invalid">Expected <xliff:g example="16" id="chunk_count">%1$s</xliff:g> chapters, but last chapter was <xliff:g example="15" id="chapter_count">%2$s</xliff:g></string>
+    <string name="label_restore">Restore</string>
 </resources>


### PR DESCRIPTION
Fix #355 associate tstudio with app.

@neutrinog - ready for review.

Here are the results of testing app association with tstudio file on the 4 devices I have:

ES File Explorer - works with all the devices I have.

Google does not provide a file manager with Android.  Each manufacturer may or may not provide their own: http://www.howtogeek.com/202644/how-to-manage-files-and-use-the-file-system-on-android/

Because of this I suspect we will see a variety of behaviors on devices.  What I saw:

- Lenovo TAB 2 - works with built-in file-manager
- NeuTab N7 Pro - KitKat 4.4.2 - built in file manager  first prompts asking the type of the file.  It gives choices of text, image, audio, or video.  I selected image and then it gave choice of apps including tstudio.  Can then launch the app.
- Asus ZenPad 8 - Android 5.0.2  - built in file manager  first prompts asking the type of the file.  It gives choices of text, image, audio, or video.  I selected image and then it gave choice of apps including tstudio.  Can then launch the app.
- LG G Pad (5.0.1) - default file manager - says file type is not supported.  No option of associating file.
