### PR TITLE
Fix #1478 Add attribution to the settings page

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,16 +138,33 @@
     <string name="preparing_upload">Preparing upload</string>
     <!-- This is the license agreement to use the app. It is formatted as HTML. -->
     <string name="license">
-<![CDATA[<h2>You are free to:</h2>
-<p>Share, copy, and redistribute the material in any medium or format; Adapt, remix, transform, and build upon the material for any purpose, even commercially. The licensor cannot revoke these freedoms as long as you follow the license terms.</p>
-<h2>Under the following terms:</h2>
+<![CDATA[
+<h2>unfoldingWord | Open Bible Stories</h2>
+<h2>an unrestricted visual mini-Bible in any language</h2>
+
 <p>
-    <b>Attribution</b> - You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use;
-    <br/><b>ShareAlike</b> - If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original;
-    <br/><b>No additional restrictions</b> -  You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
+<a href="http://openbiblestories.com" title="http://openbiblestories.com" >http://openbiblestories.com</a>
+<br/>Open Bible Stories, v. 4
+<br/>Created by Distant Shores Media (<a href="http://distantshores.org" title="http://distantshores.org" >http://distantshores.org</a>) and the Door43 world missions community (<a href="http://door43.org" title="http://door43.org" >http://door43.org</a>).
 </p>
-<h2>Notices:</h2>
-<p>You do not have to comply with the license for elements of the material in the public domain or where your use is permitted by an applicable exception or limitation; No warranties are given. The license may not give you all of the permissions necessary for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.</p>]]>
+<h2>License:</h2>
+<p>This work is made available under a Creative Commons Attribution-ShareAlike 4.0 International License (<a href="http://creativecommons.org/licenses/by-sa/4.0/" title="http://creativecommons.org/licenses/by-sa/4.0/" >http://creativecommons.org/licenses/by-sa/4.0/</a>).
+<br/>
+<br/>You are free to:
+<p>
+<b>&#8226; Share</b> - copy and redistribute the material in any medium or format
+<br/><b>&#8226; Adapt</b> - remix, transform, and build upon the material for any purpose, even commercially.
+</p>
+Under the following conditions:
+</p>
+<p>
+<b>&#8226; Attribution</b> - You must attribute the work as follows: “Original work available at <a href="http://unfoldingword.org" title="http://unfoldingword.org" >http://unfoldingword.org</a>”. Attribution statements in derivative works should not in any way suggest that we endorse you or your use of this work.
+<br/><b>&#8226; ShareAlike</b> - If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
+</p>
+<p><br/>Use of trademarks: unfoldingWord is a trademark of Distant Shores Media and may not be included on any derivative works created from this content. Unaltered content from <a href="http://unfoldingword.org" title="http://unfoldingword.org" >http://unfoldingword.org</a> must include the unfoldingWord logo when distributed to others. But if you alter the content in any way, you must remove the unfoldingWord logo before distributing your work.
+<br/>
+<br/>Attribution of artwork: All images used in these stories are © Sweet Publishing (<a href="http://www.sweetpublishing.com" title="www.sweetpublishing.com" >www.sweetpublishing.com</a>) and are made available under a Creative Commons Attribution-Share Alike License (<a href="http://creativecommons.org/licenses/by-sa/3.0" title="http://creativecommons.org/licenses/by-sa/3.0" >http://creativecommons.org/licenses/by-sa/3.0</a>).
+</p>]]>
     </string>
     <string name="choose_a_project">Please open a project</string>
     <string name="choose_a_chapter">Please open a chapter</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,12 +139,6 @@
     <!-- This is the license agreement to use the app. It is formatted as HTML. -->
     <string name="license">
 <![CDATA[
-<h2>unfoldingWord | Open Bible Stories</h2>
-<h2>an unrestricted visual mini-Bible in any language</h2>
-<p><a href="http://openbiblestories.com" title="http://openbiblestories.com" >http://openbiblestories.com</a>
-<br/>Open Bible Stories, v. 4
-<br/>Created by Distant Shores Media (<a href="http://distantshores.org" title="http://distantshores.org" >http://distantshores.org</a>) and the Door43 world missions community (<a href="http://door43.org" title="http://door43.org" >http://door43.org</a>).
-</p>
 <h2>License:</h2>
 <p>This work is made available under a Creative Commons Attribution-ShareAlike 4.0 International License (<a href="http://creativecommons.org/licenses/by-sa/4.0/" title="http://creativecommons.org/licenses/by-sa/4.0/" >http://creativecommons.org/licenses/by-sa/4.0/</a>).
 <br/>
@@ -159,9 +153,8 @@
 <br/><b>&#8226; ShareAlike</b> - If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
 <br/>
 <br/><b>Use of trademarks:</b> unfoldingWord is a trademark of Distant Shores Media and may not be included on any derivative works created from this content. Unaltered content from <a href="http://unfoldingword.org" title="http://unfoldingword.org" >http://unfoldingword.org</a> must include the unfoldingWord logo when distributed to others. But if you alter the content in any way, you must remove the unfoldingWord logo before distributing your work.
-<br/>
-<br/><b>Attribution of artwork:</b> All images used in these stories are © Sweet Publishing (<a href="http://www.sweetpublishing.com" title="www.sweetpublishing.com" >www.sweetpublishing.com</a>) and are made available under a Creative Commons Attribution-Share Alike License (<a href="http://creativecommons.org/licenses/by-sa/3.0" title="http://creativecommons.org/licenses/by-sa/3.0" >http://creativecommons.org/licenses/by-sa/3.0</a>).
-</p>]]>    </string>
+</p>]]>
+    </string>
     <string name="choose_a_project">Please open a project</string>
     <string name="choose_a_chapter">Please open a chapter</string>
     <string name="title_activity_crash_reporter">Error Report</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,9 +141,7 @@
 <![CDATA[
 <h2>unfoldingWord | Open Bible Stories</h2>
 <h2>an unrestricted visual mini-Bible in any language</h2>
-
-<p>
-<a href="http://openbiblestories.com" title="http://openbiblestories.com" >http://openbiblestories.com</a>
+<p><a href="http://openbiblestories.com" title="http://openbiblestories.com" >http://openbiblestories.com</a>
 <br/>Open Bible Stories, v. 4
 <br/>Created by Distant Shores Media (<a href="http://distantshores.org" title="http://distantshores.org" >http://distantshores.org</a>) and the Door43 world missions community (<a href="http://door43.org" title="http://door43.org" >http://door43.org</a>).
 </p>
@@ -151,21 +149,19 @@
 <p>This work is made available under a Creative Commons Attribution-ShareAlike 4.0 International License (<a href="http://creativecommons.org/licenses/by-sa/4.0/" title="http://creativecommons.org/licenses/by-sa/4.0/" >http://creativecommons.org/licenses/by-sa/4.0/</a>).
 <br/>
 <br/>You are free to:
-<p>
-<b>&#8226; Share</b> - copy and redistribute the material in any medium or format
-<br/><b>&#8226; Adapt</b> - remix, transform, and build upon the material for any purpose, even commercially.
-</p>
-Under the following conditions:
-</p>
-<p>
-<b>&#8226; Attribution</b> - You must attribute the work as follows: “Original work available at <a href="http://unfoldingword.org" title="http://unfoldingword.org" >http://unfoldingword.org</a>”. Attribution statements in derivative works should not in any way suggest that we endorse you or your use of this work.
-<br/><b>&#8226; ShareAlike</b> - If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
-</p>
-<p><br/>Use of trademarks: unfoldingWord is a trademark of Distant Shores Media and may not be included on any derivative works created from this content. Unaltered content from <a href="http://unfoldingword.org" title="http://unfoldingword.org" >http://unfoldingword.org</a> must include the unfoldingWord logo when distributed to others. But if you alter the content in any way, you must remove the unfoldingWord logo before distributing your work.
 <br/>
-<br/>Attribution of artwork: All images used in these stories are © Sweet Publishing (<a href="http://www.sweetpublishing.com" title="www.sweetpublishing.com" >www.sweetpublishing.com</a>) and are made available under a Creative Commons Attribution-Share Alike License (<a href="http://creativecommons.org/licenses/by-sa/3.0" title="http://creativecommons.org/licenses/by-sa/3.0" >http://creativecommons.org/licenses/by-sa/3.0</a>).
-</p>]]>
-    </string>
+<br/><b>&#8226; Share</b> - copy and redistribute the material in any medium or format
+<br/><b>&#8226; Adapt</b> - remix, transform, and build upon the material for any purpose, even commercially.
+<br/>
+<br/>Under the following conditions:
+<br/>
+<br/><b>&#8226; Attribution</b> - You must attribute the work as follows: “Original work available at <a href="http://unfoldingword.org" title="http://unfoldingword.org" >http://unfoldingword.org</a>”. Attribution statements in derivative works should not in any way suggest that we endorse you or your use of this work.
+<br/><b>&#8226; ShareAlike</b> - If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
+<br/>
+<br/><b>Use of trademarks:</b> unfoldingWord is a trademark of Distant Shores Media and may not be included on any derivative works created from this content. Unaltered content from <a href="http://unfoldingword.org" title="http://unfoldingword.org" >http://unfoldingword.org</a> must include the unfoldingWord logo when distributed to others. But if you alter the content in any way, you must remove the unfoldingWord logo before distributing your work.
+<br/>
+<br/><b>Attribution of artwork:</b> All images used in these stories are © Sweet Publishing (<a href="http://www.sweetpublishing.com" title="www.sweetpublishing.com" >www.sweetpublishing.com</a>) and are made available under a Creative Commons Attribution-Share Alike License (<a href="http://creativecommons.org/licenses/by-sa/3.0" title="http://creativecommons.org/licenses/by-sa/3.0" >http://creativecommons.org/licenses/by-sa/3.0</a>).
+</p>]]>    </string>
     <string name="choose_a_project">Please open a project</string>
     <string name="choose_a_chapter">Please open a chapter</string>
     <string name="title_activity_crash_reporter">Error Report</string>


### PR DESCRIPTION
Fixes #1478 Add attribution to the settings page.

Changes in this pull request:
Updated License Agreement Text to match as close as possible the text and formatting.  This is limited by the subset of html supported in Android.

@neutrinog - please take a look to see if I understood this properly.
