### PR TITLE
Fix #1477 add attribution content when printing projects

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
+++ b/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
+import com.door43.translationstudio.AppContext;
 import com.door43.translationstudio.R;
 import com.door43.translationstudio.spannables.Span;
 import com.door43.translationstudio.spannables.USFMVerseSpan;
@@ -38,7 +39,10 @@ public class PdfPrinter extends PdfPageEventHelper {
     private final Font titleFont;
     private final Font chapterFont;
     private final Font bodyFont;
+    private final Font boldBodyFont;
+    private final Font underlineBodyFont;
     private final Font subFont;
+    private final Font headingFont;
     private final TranslationFormat format;
     private final Library library;
     private final SourceTranslation sourceTranslation;
@@ -51,6 +55,8 @@ public class PdfPrinter extends PdfPageEventHelper {
     private final Map<String, Integer> pageByTitle = new HashMap<>();
     private final float PAGE_NUMBER_FONT_SIZE = 10;
     private PdfWriter writer;
+    private Paragraph mCurrentParagraph;
+
 
     public PdfPrinter(Context context, Library library, TargetTranslation targetTranslation, TranslationFormat format, String fontPath, File imagesDir) throws IOException, DocumentException {
         this.targetTranslation = targetTranslation;
@@ -60,10 +66,13 @@ public class PdfPrinter extends PdfPageEventHelper {
         this.imagesDir = imagesDir;
         this.sourceTranslation = library.getDefaultSourceTranslation(targetTranslation.getProjectId(), "en");
 
-        baseFont = BaseFont.createFont(fontPath, "UTF-8", BaseFont.EMBEDDED);
+        baseFont = BaseFont.createFont(fontPath, BaseFont.IDENTITY_H, BaseFont.EMBEDDED);
         titleFont = new Font(baseFont, 25, Font.BOLD);
         chapterFont = new Font(baseFont, 20);
         bodyFont = new Font(baseFont, 10);
+        boldBodyFont = new Font(baseFont, 10, Font.BOLD);
+        headingFont = new Font(baseFont, 14, Font.BOLD);
+        underlineBodyFont = new Font(baseFont, 10, Font.UNDERLINE);
         subFont = new Font(baseFont, 10, Font.ITALIC);
         superScriptFont = new Font(baseFont, 9);
         superScriptFont.setColor(94, 94, 94);
@@ -94,6 +103,7 @@ public class PdfPrinter extends PdfPageEventHelper {
         document.open();
         addMetaData(document);
         addTitlePage(document);
+        addLicensePage(document);
         addTOC(document);
         addContent(document);
         document.close();
@@ -102,7 +112,8 @@ public class PdfPrinter extends PdfPageEventHelper {
     }
 
     private void addTOC(Document document) throws DocumentException {
-        com.itextpdf.text.Chapter intro = new com.itextpdf.text.Chapter(new Paragraph("Table of Contents ", chapterFont), 0);
+        String toc = AppContext.context().getResources().getString(R.string.table_of_contents);
+        com.itextpdf.text.Chapter intro = new com.itextpdf.text.Chapter(new Paragraph(toc, chapterFont), 0);
         intro.setNumberDepth(0);
         document.add(intro);
 
@@ -384,5 +395,221 @@ public class PdfPrinter extends PdfPageEventHelper {
         cb.showText(text);
         cb.endText();
         cb.restoreState();
+    }
+
+    /**
+     * add the license from resource
+     * @param document
+     * @throws DocumentException
+     */
+    private void addLicensePage(Document document) throws DocumentException {
+        // title
+        String title = "";
+        Anchor anchor = new Anchor(title, chapterFont);
+        anchor.setName("name");
+        Paragraph chapterParagraph = new Paragraph(anchor);
+        chapterParagraph.setAlignment(Element.ALIGN_CENTER);
+        com.itextpdf.text.Chapter chapter = new com.itextpdf.text.Chapter(chapterParagraph, 0);
+        chapter.setNumberDepth(0);
+
+        // table for vertical alignment
+        PdfPTable table = new PdfPTable(1);
+        table.setWidthPercentage(100);
+        PdfPCell cell = new PdfPCell();
+        cell.setBorder(Rectangle.NO_BORDER);
+        cell.setMinimumHeight(document.getPageSize().getHeight() - VERTICAL_PADDING * 2);
+        cell.setVerticalAlignment(Element.ALIGN_MIDDLE);
+//        cell.addElement(chapter);
+        table.addCell(cell);
+
+        // place chapter title on it's own page
+        document.newPage();
+        document.add(chapter);
+
+        // translate simple html to paragraphs
+        String license = AppContext.context().getResources().getString(R.string.license_pdf);
+
+        license = license.replace("&#8226;", "\u2022");
+//        license = license.replace("<p>", "<br/>");
+//        license = license.replace("</p>", "<br/>");
+//        license = license.replace("<h2>", "<br/>");
+//        license = license.replace("</h2>", "<br/>");
+//        String[] lines = license.split("<br/>");
+//        for (String line : lines) {
+//            Paragraph paragraph = new Paragraph(line, bodyFont);
+//            document.add(paragraph);
+//        }
+
+        mCurrentParagraph = null;
+        parseHtml( document, license, 0);
+
+        nextParagraph(document);
+
+        document.newPage();
+    }
+
+    /**
+     * convert basic html to pdf chunks and add to document
+     * @param document
+     * @param text
+     * @param pos
+     * @throws DocumentException
+     */
+    private void parseHtml(Document document, String text, int pos) throws DocumentException {
+        if(text == null) {
+            return;
+        }
+
+        int length = text.length();
+        FoundHtml foundHtml;
+        while(pos < length) {
+            foundHtml = getNextHtml(text, pos);
+            if(null == foundHtml) {
+                break;
+            }
+
+            if(foundHtml.startPos > pos) {
+                String beforeText = text.substring(pos, foundHtml.startPos);
+                addHtmlChunk(beforeText, bodyFont);
+            }
+
+            if("b".equals(foundHtml.html)) { // bold
+                addHtmlChunk(foundHtml.enclosed, boldBodyFont);
+            } else if((foundHtml.html.length() > 0) && (foundHtml.html.charAt(0) == 'h')) { // header
+                nextParagraph(document);
+                mCurrentParagraph = new Paragraph(foundHtml.enclosed, headingFont);
+                nextParagraph(document);
+            } else if((foundHtml.html.length() > 0) && (foundHtml.html.charAt(0) == 'a')) { // anchor
+                addHtmlChunk(foundHtml.enclosed, underlineBodyFont);
+            } else if("br".equals(foundHtml.html)) { // line break
+                nextParagraph(document);
+            } else if("p".equals(foundHtml.html)) { // line break
+                blankLine(document);
+                parseHtml( document, foundHtml.enclosed, 0);
+                nextParagraph(document);
+            } else { // anything else just strip off the html tag
+                parseHtml( document, foundHtml.enclosed, 0);
+            }
+
+            pos = foundHtml.htmlFinishPos;
+        }
+
+        if(pos < length) {
+            String rest = text.substring(pos);
+            addHtmlChunk(rest, bodyFont);
+        }
+    }
+
+    /**
+     * add text to current paragraph, trim white space
+     * @param text
+     * @param font
+     * @throws DocumentException
+     */
+    private void addHtmlChunk(String text, Font font) throws DocumentException {
+        if((text != null) && !text.isEmpty()) {
+            Character c = text.charAt(0);
+            text = text.replace("\n","");
+            while((text.length() > 1) && ("  ".equals(text.substring(0,2)))) { // remove extra leading space
+                text = text.substring(1);
+            }
+            while((text.length() > 1) && ("  ".equals(text.substring(text.length() - 2)))) { // remove extra leading space
+                text = text.substring(0, text.length() - 1);
+            }
+
+            Chunk chunk = new Chunk(text, font);
+            addChunkToParagraph(chunk);
+        }
+    }
+
+    /**
+     * start a new paragraph
+     * @param document
+     * @throws DocumentException
+     */
+    private void nextParagraph(Document document) throws DocumentException {
+        if(mCurrentParagraph != null) {
+            document.add(mCurrentParagraph);
+        }
+        mCurrentParagraph = null;
+    }
+
+    /**
+     * insert a blank paragraph
+     * @param document
+     * @throws DocumentException
+     */
+    private void blankLine(Document document) throws DocumentException {
+        nextParagraph(document);
+        mCurrentParagraph = new Paragraph(" ", bodyFont);
+        nextParagraph(document);
+    }
+
+    /**
+     * add a chunk to current paragraph
+     * @param chunk
+     * @throws DocumentException
+     */
+    private void addChunkToParagraph(Chunk chunk) throws DocumentException {
+        if(null == mCurrentParagraph) {
+            mCurrentParagraph = new Paragraph("", bodyFont);
+        }
+        mCurrentParagraph.add(chunk);
+    }
+
+    /**
+     * get next html tag from start pos
+     * @param text
+     * @param startPos
+     * @return
+     */
+    private FoundHtml getNextHtml(String text, int startPos) {
+        int pos = text.indexOf("<", startPos);
+        if(pos < 0) {
+            return null;
+        }
+
+        int end = text.indexOf(">", pos + 1);
+        int length = text.length();
+        if(end < 0) {
+            return new FoundHtml(text.substring(pos + 1), pos, length, "");
+        }
+
+        String token = text.substring(pos + 1, end);
+        if(!token.isEmpty() && (token.charAt(token.length() - 1) == '/')) {
+            return new FoundHtml(token.substring(0, token.length() - 1), pos, end + 1, "");
+        }
+
+        String[] parts = token.split(" "); // ignore attibutes
+        String endToken = "</" + parts[0] + ">";
+        int finish = text.indexOf(endToken, end + 1);
+        if(finish < 0) { // if end token not found, then stop at next
+            int next = text.indexOf("<", end + 1);
+            if(next < 0) {
+                return new FoundHtml(token, pos, length, text.substring(end + 1, length));
+            } else {
+                return new FoundHtml(token, pos, next, text.substring(end + 1, next));
+            }
+        }
+
+        int htmlFinishPos = finish + endToken.length();
+        return new FoundHtml(token, pos, htmlFinishPos, text.substring(end + 1, finish));
+    }
+
+    /**
+     * class for keeping track of an html tag that was found, it's name, it's contents, and position
+     */
+    private class FoundHtml {
+        public String html;
+        public String enclosed;
+        public int startPos;
+        public int htmlFinishPos;
+
+        public FoundHtml(String html, int startPos, int htmlFinishPos, String enclosed) {
+            this.html = html;
+            this.startPos = startPos;
+            this.htmlFinishPos = htmlFinishPos;
+            this.enclosed = enclosed;
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -742,4 +742,31 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
     <string name="could_not_parse">Could not parse \'<xliff:g example="Mark.usfm" id="file_name">%1$s</xliff:g>\'</string>
     <string name="no_chunk_list">No chunk list found for \'<xliff:g example="marc" id="book_name">%1$s</xliff:g>\'</string>
     <string name="chapter_count_invalid">Expected <xliff:g example="16" id="chunk_count">%1$s</xliff:g> chapters, but last chapter was <xliff:g example="15" id="chapter_count">%2$s</xliff:g></string>
+    <string name="table_of_contents">Table of Contents </string>
+    <string name="license_pdf">
+<![CDATA[
+<h2>unfoldingWord | Open Bible Stories</h2>
+<h2>an unrestricted visual mini-Bible in any language</h2>
+<p><a href="http://openbiblestories.com" title="http://openbiblestories.com" >http://openbiblestories.com</a>
+<br/>Open Bible Stories, v. 4
+<br/>Created by Distant Shores Media (<a href="http://distantshores.org" title="http://distantshores.org" >http://distantshores.org</a>) and the Door43 world missions community (<a href="http://door43.org" title="http://door43.org" >http://door43.org</a>).
+</p>
+<h2>License:</h2>
+<p>This work is made available under a Creative Commons Attribution-ShareAlike 4.0 International License (<a href="http://creativecommons.org/licenses/by-sa/4.0/" title="http://creativecommons.org/licenses/by-sa/4.0/" >http://creativecommons.org/licenses/by-sa/4.0/</a>).
+<br/>
+<br/>You are free to:
+<br/>
+<br/><b>&#8226; Share</b> - copy and redistribute the material in any medium or format
+<br/><b>&#8226; Adapt</b> - remix, transform, and build upon the material for any purpose, even commercially.
+<br/>
+<br/>Under the following conditions:
+<br/>
+<br/><b>&#8226; Attribution</b> - You must attribute the work as follows: “Original work available at <a href="http://unfoldingword.org" title="http://unfoldingword.org" >http://unfoldingword.org</a>”. Attribution statements in derivative works should not in any way suggest that we endorse you or your use of this work.
+<br/><b>&#8226; ShareAlike</b> - If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
+<br/>
+<br/><b>Use of trademarks:</b> unfoldingWord is a trademark of Distant Shores Media and may not be included on any derivative works created from this content. Unaltered content from <a href="http://unfoldingword.org" title="http://unfoldingword.org" >http://unfoldingword.org</a> must include the unfoldingWord logo when distributed to others. But if you alter the content in any way, you must remove the unfoldingWord logo before distributing your work.
+<br/>
+<br/><b>Attribution of artwork:</b> All images used in these stories are © Sweet Publishing (<a href="http://www.sweetpublishing.com" title="www.sweetpublishing.com" >www.sweetpublishing.com</a>) and are made available under a Creative Commons Attribution-Share Alike License (<a href="http://creativecommons.org/licenses/by-sa/3.0" title="http://creativecommons.org/licenses/by-sa/3.0" >http://creativecommons.org/licenses/by-sa/3.0</a>).
+</p>]]>
+    </string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -745,12 +745,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
     <string name="table_of_contents">Table of Contents </string>
     <string name="license_pdf">
 <![CDATA[
-<h2>unfoldingWord | Open Bible Stories</h2>
-<h2>an unrestricted visual mini-Bible in any language</h2>
-<p><a href="http://openbiblestories.com" title="http://openbiblestories.com" >http://openbiblestories.com</a>
-<br/>Open Bible Stories, v. 4
-<br/>Created by Distant Shores Media (<a href="http://distantshores.org" title="http://distantshores.org" >http://distantshores.org</a>) and the Door43 world missions community (<a href="http://door43.org" title="http://door43.org" >http://door43.org</a>).
-</p>
 <h2>License:</h2>
 <p>This work is made available under a Creative Commons Attribution-ShareAlike 4.0 International License (<a href="http://creativecommons.org/licenses/by-sa/4.0/" title="http://creativecommons.org/licenses/by-sa/4.0/" >http://creativecommons.org/licenses/by-sa/4.0/</a>).
 <br/>
@@ -765,8 +759,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 <br/><b>&#8226; ShareAlike</b> - If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
 <br/>
 <br/><b>Use of trademarks:</b> unfoldingWord is a trademark of Distant Shores Media and may not be included on any derivative works created from this content. Unaltered content from <a href="http://unfoldingword.org" title="http://unfoldingword.org" >http://unfoldingword.org</a> must include the unfoldingWord logo when distributed to others. But if you alter the content in any way, you must remove the unfoldingWord logo before distributing your work.
-<br/>
-<br/><b>Attribution of artwork:</b> All images used in these stories are © Sweet Publishing (<a href="http://www.sweetpublishing.com" title="www.sweetpublishing.com" >www.sweetpublishing.com</a>) and are made available under a Creative Commons Attribution-Share Alike License (<a href="http://creativecommons.org/licenses/by-sa/3.0" title="http://creativecommons.org/licenses/by-sa/3.0" >http://creativecommons.org/licenses/by-sa/3.0</a>).
 </p>]]>
     </string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,16 +138,22 @@
     <string name="preparing_upload">Preparing upload</string>
     <!-- This is the license agreement to use the app. It is formatted as HTML. -->
     <string name="license">
-<![CDATA[<h2>You are free to:</h2>
-<p>Share, copy, and redistribute the material in any medium or format; Adapt, remix, transform, and build upon the material for any purpose, even commercially. The licensor cannot revoke these freedoms as long as you follow the license terms.</p>
-<h2>Under the following terms:</h2>
-<p>
-    <b>Attribution</b> - You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use;
-    <br/><b>ShareAlike</b> - If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original;
-    <br/><b>No additional restrictions</b> -  You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
-</p>
-<h2>Notices:</h2>
-<p>You do not have to comply with the license for elements of the material in the public domain or where your use is permitted by an applicable exception or limitation; No warranties are given. The license may not give you all of the permissions necessary for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.</p>]]>
+<![CDATA[
+<h2>License:</h2>
+<p>This work is made available under a Creative Commons Attribution-ShareAlike 4.0 International License (<a href="http://creativecommons.org/licenses/by-sa/4.0/" title="http://creativecommons.org/licenses/by-sa/4.0/" >http://creativecommons.org/licenses/by-sa/4.0/</a>).
+<br/>
+<br/>You are free to:
+<br/>
+<br/><b>&#8226; Share</b> - copy and redistribute the material in any medium or format
+<br/><b>&#8226; Adapt</b> - remix, transform, and build upon the material for any purpose, even commercially.
+<br/>
+<br/>Under the following conditions:
+<br/>
+<br/><b>&#8226; Attribution</b> - You must attribute the work as follows: “Original work available at <a href="http://unfoldingword.org" title="http://unfoldingword.org" >http://unfoldingword.org</a>”. Attribution statements in derivative works should not in any way suggest that we endorse you or your use of this work.
+<br/><b>&#8226; ShareAlike</b> - If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
+<br/>
+<br/><b>Use of trademarks:</b> unfoldingWord is a trademark of Distant Shores Media and may not be included on any derivative works created from this content. Unaltered content from <a href="http://unfoldingword.org" title="http://unfoldingword.org" >http://unfoldingword.org</a> must include the unfoldingWord logo when distributed to others. But if you alter the content in any way, you must remove the unfoldingWord logo before distributing your work.
+</p>]]>
     </string>
     <string name="choose_a_project">Please open a project</string>
     <string name="choose_a_chapter">Please open a chapter</string>


### PR DESCRIPTION
Fix #1477 add attribution content when printing projects

Changes in this pull request:
Fixed unicode fonts for printing foreign symbols.
Extended PDF printer to convert basic html to PDF chunks and paragraphs.

@neutrinog 