### PR TITLE
Fix #1457 type in verse markers while typing

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
@@ -550,7 +550,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                     mgr.showSoftInput(holder.mTargetEditableBody, InputMethodManager.SHOW_IMPLICIT);
 
                     // TRICKY: there may be changes to translation
-                    item.loadTranslations(mSourceTranslation, mTargetTranslation, chapter, frame);
+                     item.loadTranslations(mSourceTranslation, mTargetTranslation, chapter, frame);
 
                     // re-render for editing mode
                     item.renderedTargetBody = renderSourceText(item.bodyTranslation, item.translationFormat, holder, item, true);
@@ -1070,7 +1070,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
             int lastVerseSeen = 0;
             while (matcher.find()) {
                 int currentVerse = Integer.valueOf(matcher.group(1));
-                if (currentVerse < lastVerseSeen) {
+                if (currentVerse <= lastVerseSeen) {
                     success = false;
                     break;
                 } else {
@@ -1441,6 +1441,11 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                                     text = TextUtils.concat(pin.toCharSequence(), text);
                                     item.renderedTargetBody = text;
                                     editText.setText(text);
+                                    String translation = Translator.compileTranslation((Editable)editText.getText());
+                                    mTargetTranslation.applyFrameTranslation(frameTranslation, translation);
+
+                                    // Reload, so that bodyTranslation and other data are kept in sync.
+                                    item.loadTranslations(mSourceTranslation, mTargetTranslation, null, frame);
                                 }
                             } else if(event.getAction() == DragEvent.ACTION_DRAG_ENTERED) {
                                 hasEntered = true;

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
@@ -61,6 +61,7 @@ import com.door43.translationstudio.rendering.ClickableRenderingEngine;
 import com.door43.translationstudio.spannables.NoteSpan;
 import com.door43.translationstudio.spannables.USFMNoteSpan;
 import com.door43.translationstudio.spannables.Span;
+import com.door43.translationstudio.spannables.USFMVerseSpan;
 import com.door43.translationstudio.spannables.VerseSpan;
 import com.door43.util.tasks.ThreadableUI;
 import com.door43.widget.ViewUtil;
@@ -643,7 +644,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                                             if(!item.isEditing) { // make sure to capture verse marker changes
                                                 item.renderedTargetBody = holder.mTargetEditableBody.getText();
                                             }
-                                            boolean success = onConfirmChunk(item, chapter, frame);
+                                            boolean success = onConfirmChunk(item, chapter, frame, mTargetTranslation.getFormat());
                                             holder.mDoneSwitch.setChecked(success);
                                         }
                                     }
@@ -1032,6 +1033,12 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
         thread.start();
     }
 
+    private static final Pattern USFM_CONSECUTIVE_VERSE_MARKERS =
+            Pattern.compile("(" + USFMVerseSpan.PATTERN + "){2}");
+
+    private static final Pattern USFM_VERSE_MARKER =
+            Pattern.compile(USFMVerseSpan.PATTERN);
+
     private static final Pattern CONSECUTIVE_VERSE_MARKERS =
             Pattern.compile("(<verse [^>]+/>\\s*){2}");
 
@@ -1042,7 +1049,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
      * Performs some validation, and commits changes if ready.
      * @return true if the section was successfully confirmed; otherwise false.
      */
-    private boolean onConfirmChunk(final ListItem item, final Chapter chapter, final Frame frame) {
+    private boolean onConfirmChunk(final ListItem item, final Chapter chapter, final Frame frame, TranslationFormat format) {
         boolean success = true; // So far, so good.
 
         // Check for empty translation.
@@ -1053,9 +1060,25 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
             success = false;
         }
 
+        Matcher matcher;
+        int lowVerse = -1;
+        int highVerse = 999999999;
+        int[] range = frame.getVerseRange();
+        if( (range != null) && (range.length > 0)) {
+            lowVerse = range[0];
+            highVerse = lowVerse;
+            if (range.length > 1) {
+                highVerse = range[1];
+            }
+        }
+
         // Check for contiguous verse numbers.
         if (success) {
-            Matcher matcher = CONSECUTIVE_VERSE_MARKERS.matcher(item.bodyTranslation);
+            if(format == TranslationFormat.USFM) {
+                matcher = USFM_CONSECUTIVE_VERSE_MARKERS.matcher(item.bodyTranslation);
+            } else {
+                matcher = CONSECUTIVE_VERSE_MARKERS.matcher(item.bodyTranslation);
+            }
             if (matcher.find()) {
                 Snackbar snack = Snackbar.make(mContext.findViewById(android.R.id.content), R.string.consecutive_verse_markers, Snackbar.LENGTH_LONG);
                 ViewUtil.setSnackBarTextColor(snack, mContext.getResources().getColor(R.color.light_primary_text));
@@ -1066,11 +1089,21 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
 
         // Check for out-of-order verse markers.
         if (success) {
-            Matcher matcher = VERSE_MARKER.matcher(item.bodyTranslation);
+            int error = 0;
+            if(format == TranslationFormat.USFM) {
+                matcher = USFM_VERSE_MARKER.matcher(item.bodyTranslation);
+            } else {
+                matcher = VERSE_MARKER.matcher(item.bodyTranslation);
+            }
             int lastVerseSeen = 0;
             while (matcher.find()) {
                 int currentVerse = Integer.valueOf(matcher.group(1));
                 if (currentVerse <= lastVerseSeen) {
+                    error = R.string.outoforder_verse_markers;
+                    success = false;
+                    break;
+                } else if( (currentVerse < lowVerse) || (currentVerse > highVerse) ) {
+                    error = R.string.outofrange_verse_marker;
                     success = false;
                     break;
                 } else {
@@ -1078,7 +1111,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                 }
             }
             if (!success) {
-                Snackbar snack = Snackbar.make(mContext.findViewById(android.R.id.content), R.string.outoforder_verse_markers, Snackbar.LENGTH_LONG);
+                Snackbar snack = Snackbar.make(mContext.findViewById(android.R.id.content), error, Snackbar.LENGTH_LONG);
                 ViewUtil.setSnackBarTextColor(snack, mContext.getResources().getColor(R.color.light_primary_text));
                 snack.show();
             }

--- a/app/src/main/java/com/door43/translationstudio/rendering/USFMRenderer.java
+++ b/app/src/main/java/com/door43/translationstudio/rendering/USFMRenderer.java
@@ -332,12 +332,14 @@ public class USFMRenderer extends ClickableRenderingEngine {
                             verse.setOnClickListener(mVerseListener);
                             out = TextUtils.concat(out, in.subSequence(lastIndex, matcher.start()), insert, verse.toCharSequence());
                         } else {
-                            // exclude invalid verse
-                            out = TextUtils.concat(out, in.subSequence(lastIndex, matcher.start()));
+                            // for now we go ahead and render invalid verse
+                            verse.setOnClickListener(mVerseListener);
+                            out = TextUtils.concat(out, in.subSequence(lastIndex, matcher.start()), insert, verse.toCharSequence());
                         }
                     } else {
-                        // exclude duplicate verse
-                        out = TextUtils.concat(out, in.subSequence(lastIndex, matcher.start()));
+                        // for now we go ahead and render duplicate verse
+                        verse.setOnClickListener(mVerseListener);
+                        out = TextUtils.concat(out, in.subSequence(lastIndex, matcher.start()), insert, verse.toCharSequence());
                     }
                 } else {
                     // failed to parse the verse

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -349,6 +349,7 @@
     <string name="translate_first">Please provide a translation first</string>
     <string name="consecutive_verse_markers">Verse markers are placed too close to each other. Please verify marker positions.</string>
     <string name="outoforder_verse_markers">Verse markers are out of order</string>
+    <string name="outofrange_verse_marker">Verse marker is out of range</string>
     <string name="failed_to_commit_chunk">The chunk could not be saved</string>
     <string name="title_activity_publish">Publish Translation</string>
 


### PR DESCRIPTION
Fixes #1457 type in verse markers while typing.

Changes in this pull request:
- Fix issue with dragging verse markers. Now when verse marker is dragged off screen and positioned to beginning, then change is now saved.
- Change to not hide duplicate or out of range verses. Will allow user to manually clean up.
- Expand onConfirmChunk() to handle USFM verse markers and do verse range checking.

@neutrinog - ready for review.