### PR TITLE
Fix #1427 should not be able to place verse markers inside word

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
@@ -76,7 +76,6 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.revwalk.RevCommit;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -1499,6 +1498,9 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                             } else if(event.getAction() == DragEvent.ACTION_DROP) {
                                 int offset = editText.getOffsetForPosition(event.getX(), event.getY());
                                 CharSequence text = editText.getText();
+
+                                offset = closestSpotForVerseMarker(offset, text);
+
                                 if(offset >= 0) {
                                     // insert the verse at the offset
                                     text = TextUtils.concat(text.subSequence(0, offset), pin.toCharSequence(), text.subSequence(offset, text.length()));
@@ -1577,6 +1579,58 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
         } else {
             return "";
         }
+    }
+
+    /**
+     * find closest place to drop verse marker.  Weighted toward beginning of word.
+     * @param offset - initial drop position
+     * @param text - edit text
+     * @return
+     */
+    private int closestSpotForVerseMarker(int offset, CharSequence text) {
+        int charsToWhiteSpace = 0;
+        for (int j = offset; j >= 0; j--) {
+            char c = text.charAt(j);
+            boolean whitespace = isWhitespace(c);
+            if(whitespace) {
+
+                if((j == offset) ||  // if this is already a good spot, then done
+                    (j == offset - 1)) {
+                    return offset;
+                }
+
+                charsToWhiteSpace = j - offset + 1;
+                break;
+            }
+        }
+
+        int limit = offset - charsToWhiteSpace - 1;
+        if(limit > text.length()) {
+            limit = text.length();
+        }
+
+        for (int j = offset + 1; j < limit; j++) {
+            char c = text.charAt(j);
+            boolean whitespace = isWhitespace(c);
+            if(whitespace) {
+                charsToWhiteSpace = j - offset;
+                break;
+            }
+        }
+
+        if(charsToWhiteSpace != 0) {
+            offset += charsToWhiteSpace;
+        }
+        return offset;
+    }
+
+    /**
+     * test if character is whitespace
+     * @param c
+     * @return
+     */
+    private boolean isWhitespace(char c) {
+        return (c ==' ') || (c == '\t') || (c == '\n') || (c == '\r');
     }
 
     /**


### PR DESCRIPTION
Fix #1427 should not be able to place verse markers inside word .

Changes in this pull request:
- on drop of verse marker, if marker isn't in whitespace, then it is moved to closest whitespace.  It is biased toward whitespace before (start of word).