### PR TITLE
Fix #1563 app displays source translations before they are downloaded

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/core/Library.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Library.java
@@ -22,7 +22,7 @@ import java.util.Locale;
  * Created by joel on 8/29/2015.
  */
 public class Library {
-    private static final int MIN_CHECKING_LEVEL = 3; // the minimum level to be considered a source translation
+    public static final int MIN_CHECKING_LEVEL = 3; // the minimum level to be considered a source translation
     private static final String DEFAULT_RESOURCE_SLUG = "ulb";
     private static final String IMAGES_DIR = "images";
     public static final String TAG = Library.class.toString();
@@ -744,6 +744,15 @@ public class Library {
      * @param projectId
      */
     public SourceTranslation[] getSourceTranslations(String projectId) {
+        return getSourceTranslations( projectId, MIN_CHECKING_LEVEL);
+    }
+
+    /**
+     * Returns an array of source translations in a project that have met the minimum checking level
+     * @param projectId
+     * @param checkingLevel - acceptable checking level
+     */
+    public SourceTranslation[] getSourceTranslations(String projectId, int checkingLevel) {
         // TODO: write a query for this
         List<SourceTranslation> sourceTranslations = new ArrayList<>();
         String[] sourceLanguageIds = getActiveIndex().getSourceLanguageSlugs(projectId);
@@ -751,7 +760,7 @@ public class Library {
             String[] resourceIds = getActiveIndex().getResourceSlugs(projectId, sourceLanguageId);
             for(String resourceId:resourceIds) {
                 SourceTranslation sourceTranslation = getSourceTranslation(projectId, sourceLanguageId, resourceId);
-                if(sourceTranslation != null && sourceTranslation.getCheckingLevel() >= MIN_CHECKING_LEVEL) {
+                if(sourceTranslation != null && sourceTranslation.getCheckingLevel() >= checkingLevel) {
                     sourceTranslations.add(sourceTranslation);
                 }
             }

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationAdapter.java
@@ -1,6 +1,8 @@
 package com.door43.translationstudio.newui.translate;
 
 import android.content.Context;
+import android.content.DialogInterface;
+import android.support.v7.app.AlertDialog;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -85,14 +87,46 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter  implements Mana
                 break;
 
             case TYPE_ITEM_NEED_DOWNLOAD:
-                DownloadSourceLanguageTask task = new DownloadSourceLanguageTask(item.sourceTranslation.projectSlug, item.sourceTranslation.sourceLanguageSlug);
-                task.addOnFinishedListener(this);
-                TaskManager.addTask(task, item.sourceTranslation.projectSlug + "-" + item.id);
-                TaskManager.groupTask(task, ServerLibraryDetailFragment.DOWNLOAD_SOURCE_LANGUAGE_TASK_GROUP);
+                promptToDownloadSourceLangauge(item);
                 break;
         }
     }
 
+    /**
+     * make sure the user is aware that download will use the internet
+     * @param item
+     */
+    private void promptToDownloadSourceLangauge(final ViewItem item) {
+        String format = mContext.getResources().getString(R.string.download_source_language);
+        String message = String.format(format, item.title);
+        new AlertDialog.Builder(mContext, R.style.AppTheme_Dialog)
+                .setTitle(R.string.title_download_source_language)
+                .setMessage(message)
+                .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        downloadSourceLanguage(item);
+                    }
+                })
+                .setNegativeButton(R.string.no, null)
+                .show();
+    }
+
+    /**
+     * initiate download
+     * @param item
+     */
+    private void downloadSourceLanguage(ViewItem item) {
+        DownloadSourceLanguageTask task = new DownloadSourceLanguageTask(item.sourceTranslation.projectSlug, item.sourceTranslation.sourceLanguageSlug);
+        task.addOnFinishedListener(this);
+        TaskManager.addTask(task, item.sourceTranslation.projectSlug + "-" + item.id);
+        TaskManager.groupTask(task, ServerLibraryDetailFragment.DOWNLOAD_SOURCE_LANGUAGE_TASK_GROUP);
+    }
+
+    /**
+     * called when download is finished
+     * @param task
+     */
     public void onTaskFinished(ManagedTask task) {
         DownloadSourceLanguageTask downloadTask = (DownloadSourceLanguageTask) task;
         Library library = App.getLibrary();

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationAdapter.java
@@ -14,13 +14,11 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.door43.translationstudio.App;
-import com.door43.translationstudio.DeveloperToolsActivity;
 import com.door43.translationstudio.R;
 import com.door43.translationstudio.core.Library;
 import com.door43.translationstudio.core.Resource;
 import com.door43.translationstudio.core.SourceTranslation;
 import com.door43.translationstudio.newui.library.ServerLibraryDetailFragment;
-import com.door43.translationstudio.tasks.DownloadAllProjectsTask;
 import com.door43.translationstudio.tasks.DownloadSourceLanguageTask;
 import com.door43.widget.ViewUtil;
 
@@ -68,7 +66,7 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter  implements Mana
     public void addItem(final ViewItem item) {
         if(!mData.containsKey(item.id)) {
             mData.put(item.id, item);
-            if(item.selected) {
+            if(item.selected  && item.downloaded) {
                 mSelected.add(item.id);
             } else {
                 mAvailable.add(item.id);
@@ -142,7 +140,7 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter  implements Mana
         if (progressDialog != null) {
             progressDialog.dismiss();
         }
-        
+
         if(downloadTask.isFinished() && downloadTask.getSuccess()) {
             boolean databaseChanged = false;
             String sourceLang = downloadTask.getSourceLanguageId();

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationDialog.java
@@ -21,6 +21,8 @@ import com.door43.translationstudio.core.SourceTranslation;
 import com.door43.translationstudio.core.TargetTranslation;
 import com.door43.translationstudio.core.Translator;
 
+import org.unfoldingword.tools.logger.Logger;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,6 +31,7 @@ import java.util.List;
  */
 public class ChooseSourceTranslationDialog extends DialogFragment {
     public static final String ARG_TARGET_TRANSLATION_ID = "arg_target_translation_id";
+    public static final String TAG = ChooseSourceTranslationDialog.class.getSimpleName();
     private Translator mTranslator;
     private TargetTranslation mTargetTranslation;
     private OnClickListener mListener;
@@ -157,9 +160,12 @@ public class ChooseSourceTranslationDialog extends DialogFragment {
         }
 
         Resource resource = mLibrary.getResource( sourceTranslation);
-        boolean downloaded = resource.isDownloaded();
-        String projectID = sourceTranslation.projectSlug;
-        mAdapter.addItem(new ChooseSourceTranslationAdapter.ViewItem(title, sourceTranslation.getId(), projectID, selected, downloaded));
+        if(resource != null) {
+            boolean downloaded = resource.isDownloaded();
+            mAdapter.addItem(new ChooseSourceTranslationAdapter.ViewItem(title, sourceTranslation, selected, downloaded));
+        } else {
+            Logger.e(TAG, "Failed to get resource for " + sourceTranslation.getId());
+        }
     }
 
     /**

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationDialog.java
@@ -16,6 +16,7 @@ import android.widget.ListView;
 import com.door43.translationstudio.App;
 import com.door43.translationstudio.R;
 import com.door43.translationstudio.core.Library;
+import com.door43.translationstudio.core.Resource;
 import com.door43.translationstudio.core.SourceTranslation;
 import com.door43.translationstudio.core.TargetTranslation;
 import com.door43.translationstudio.core.Translator;
@@ -99,13 +100,8 @@ public class ChooseSourceTranslationDialog extends DialogFragment {
         listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                if(mAdapter.getItemViewType(position) == ChooseSourceTranslationAdapter.TYPE_ITEM) {
-                    ChooseSourceTranslationAdapter.ViewItem item = mAdapter.getItem(position);
-                    if(item.selected) {
-                        mAdapter.deselect(position);
-                    } else {
-                        mAdapter.select(position);
-                    }
+                if(mAdapter.isSelectableItem(position)) {
+                    mAdapter.doClickOnItem(position);
                     mAdapter.sort();
                 }
             }
@@ -129,7 +125,7 @@ public class ChooseSourceTranslationDialog extends DialogFragment {
                 int count = mAdapter.getCount();
                 List<String> sourceTranslationIds = new ArrayList<>();
                 for(int i = 0; i < count; i ++) {
-                    if(mAdapter.getItemViewType(i) == ChooseSourceTranslationAdapter.TYPE_ITEM) {
+                    if(mAdapter.isSelectableItem(i)) {
                         ChooseSourceTranslationAdapter.ViewItem item = mAdapter.getItem(i);
                         if(item.selected) {
                             sourceTranslationIds.add(item.id);
@@ -155,7 +151,9 @@ public class ChooseSourceTranslationDialog extends DialogFragment {
             title = newTitle;
         }
 
-        mAdapter.addItem(new ChooseSourceTranslationAdapter.ViewItem(title, sourceTranslation.getId(), selected));
+        Resource resource = mLibrary.getResource( sourceTranslation);
+        boolean downloaded = resource.isDownloaded();
+        mAdapter.addItem(new ChooseSourceTranslationAdapter.ViewItem(title, sourceTranslation.getId(), selected, downloaded));
     }
 
     /**

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationDialog.java
@@ -142,6 +142,11 @@ public class ChooseSourceTranslationDialog extends DialogFragment {
         return v;
     }
 
+    /**
+     * adds this source translation to the adapter
+     * @param sourceTranslation
+     * @param selected
+     */
     private void addSourceTranslation(SourceTranslation sourceTranslation, boolean selected) {
         String title = sourceTranslation.getSourceLanguageTitle() + " - " + sourceTranslation.getResourceTitle();
 
@@ -153,7 +158,8 @@ public class ChooseSourceTranslationDialog extends DialogFragment {
 
         Resource resource = mLibrary.getResource( sourceTranslation);
         boolean downloaded = resource.isDownloaded();
-        mAdapter.addItem(new ChooseSourceTranslationAdapter.ViewItem(title, sourceTranslation.getId(), selected, downloaded));
+        String projectID = sourceTranslation.projectSlug;
+        mAdapter.addItem(new ChooseSourceTranslationAdapter.ViewItem(title, sourceTranslation.getId(), projectID, selected, downloaded));
     }
 
     /**

--- a/app/src/main/java/com/door43/translationstudio/tasks/DownloadSourceLanguageTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/DownloadSourceLanguageTask.java
@@ -40,6 +40,13 @@ public class DownloadSourceLanguageTask extends ManagedTask {
     public void start() {
         publishProgress(-1, "");
         final Resource[] resources = mLibrary.getResources(mProjectId, mSourceLanguageId);
+        // TODO: 7/29/16 should add error handling here
+//        if((resources == null) || (resources.length == 0)) {
+//            Logger.e(TAG,"Could not find resources for project " + mProjectId + " and source language " + mSourceLanguageId);
+//            mSuccess = false;
+//            return;
+//        }
+
         mSuccess = true;
         for(int i = 0; i < resources.length; i ++) {
             // TODO: hook up progress listener

--- a/app/src/main/res/layout/fragment_select_source_translation_list_download_item.xml
+++ b/app/src/main/res/layout/fragment_select_source_translation_list_download_item.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal" android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingRight="16dp"
+    android:paddingLeft="16dp"
+    android:paddingTop="10dp"
+    android:paddingBottom="10dp">
+
+    <TextView
+        android:layout_gravity="center_vertical"
+        android:layout_width="wrap_content"
+        android:layout_weight="1"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/body"
+        android:textColor="@color/dark_primary_text"
+        android:text="English - Unlocked Literal Bible"
+        android:id="@+id/title" />
+
+    <ImageView
+        android:layout_gravity="center_vertical"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="16dp"
+        android:background="@drawable/ic_file_download_black_24dp"
+        android:id="@+id/download_resource" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -806,5 +806,7 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
     <string name="download_latest_apk">Do you want to download this update?</string>
     <string name="updating_projects">Updating projects</string>
     <string name="view_online">View Online</string>
-    <string name="draft_translation">Draft Level <xliff:g example="3" id="checking_level">%1$d</xliff:g>: <xliff:g example="Pig Latin" id="checking_level">%2$s</xliff:g></string>
+    <string name="draft_translation">Draft Level <xliff:g example="3" id="checking_level">%1$d</xliff:g>: <xliff:g example="Pig Latin" id="language">%2$s</xliff:g></string>
+    <string name="title_download_source_language">Download from Online</string>
+    <string name="download_source_language">Do you want to download \'<xliff:g example="Pig Latin" id="language">%1$s</xliff:g>\' from Online (requires internet)?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -819,4 +819,5 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
     <string name="draft_translation">Draft Level <xliff:g example="3" id="checking_level">%1$d</xliff:g>: <xliff:g example="Pig Latin" id="language">%2$s</xliff:g></string>
     <string name="title_download_source_language">Download from Online</string>
     <string name="download_source_language">Do you want to download \'<xliff:g example="Pig Latin" id="language">%1$s</xliff:g>\' from Online (requires internet)?</string>
+    <string name="downloading_source">Downloading source <xliff:g example="en" id="source_language">%1$s</xliff:g></string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -806,4 +806,5 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
     <string name="download_latest_apk">Do you want to download this update?</string>
     <string name="updating_projects">Updating projects</string>
     <string name="view_online">View Online</string>
+    <string name="draft_translation">Draft Level <xliff:g example="3" id="checking_level">%1$d</xliff:g>: <xliff:g example="Pig Latin" id="checking_level">%2$s</xliff:g></string>
 </resources>


### PR DESCRIPTION
Fix #1563 app displays source translations before they are downloaded

Changes in this pull request:
- Could not reproduce the original issue, but made change to show all the sources for a project regardless of whether loaded or not.
- Sources that are not loaded show a download icon in place of checkbox.  When item is selected the user is warned that this will use the internet and must approve before proceeding.
- progress dialog is displayed during download.
- Draft sources are displayed with their checking level.

@neutrinog - please check to see if this approach is fine.