### PR TITLE
Fix 1578 images are not printed even though requested

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/core/Library.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Library.java
@@ -396,7 +396,7 @@ public class Library {
     }
 
     /**
-     * Indicates whether the imagery download is complete and extraction was successful.  zip files are ignored since failed download will leave a file there.
+     * Indicates whether the imagery download is complete and extraction was successful.  zip files are ignored since a failed download can leave a zip file there.
      *
      * <p>If any part of the process was not complete, this returns false. This method makes no
      * statement as to the freshness of the information downloaded.</p>

--- a/app/src/main/java/com/door43/translationstudio/core/Library.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Library.java
@@ -396,7 +396,7 @@ public class Library {
     }
 
     /**
-     * Indicates whether the imagery download is complete and extraction was successful.
+     * Indicates whether the imagery download is complete and extraction was successful.  zip files are ignored since failed download will leave a file there.
      *
      * <p>If any part of the process was not complete, this returns false. This method makes no
      * statement as to the freshness of the information downloaded.</p>
@@ -406,7 +406,15 @@ public class Library {
         String[] names =  getImagesDir().list(new FilenameFilter() {
             @Override
             public boolean accept(File dir, String filename) {
-                return !new File(dir, filename).isDirectory();
+                File testFile = new File(dir, filename);
+                boolean isFile = !testFile.isDirectory();
+                if(isFile) {
+                    String extension = FileUtilities.getExtension(testFile.getName());
+                    if( !"zip".equalsIgnoreCase(extension)) {
+                        return true;
+                    }
+                }
+                return false; // is not an image file
             }
         });
         return names != null && names.length > 0;

--- a/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
+++ b/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
@@ -254,7 +254,7 @@ public class PdfPrinter extends PdfPageEventHelper {
                         // TODO: 11/13/2015 insert frame images if we have them.
                         // TODO: 11/13/2015 eventually we need to provide the directory where to find these images which will be downloaded not in assets
                         try {
-                            File imageFile = new File(imagesDir, "360px/" + targetTranslation.getProjectId() + "-" + f.getComplexId() + ".jpg");
+                            File imageFile = new File(imagesDir, targetTranslation.getProjectId() + "-" + f.getComplexId() + ".jpg");
                             if(imageFile.exists()) {
                                 addImage(document, imageFile.getAbsolutePath());
                             }

--- a/app/src/main/java/com/door43/translationstudio/newui/PrintDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/PrintDialog.java
@@ -25,11 +25,15 @@ import com.door43.translationstudio.core.TargetTranslation;
 import com.door43.translationstudio.core.Translator;
 import com.door43.translationstudio.tasks.DownloadImagesTask;
 import com.door43.translationstudio.tasks.PrintPDFTask;
+import com.door43.util.FileUtilities;
+
+import org.unfoldingword.tools.logger.Logger;
 import org.unfoldingword.tools.taskmanager.SimpleTaskWatcher;
 import org.unfoldingword.tools.taskmanager.ManagedTask;
 import org.unfoldingword.tools.taskmanager.TaskManager;
 
 import java.io.File;
+import java.io.IOException;
 import java.security.InvalidParameterException;
 import java.util.Locale;
 
@@ -43,6 +47,7 @@ public class PrintDialog extends DialogFragment implements SimpleTaskWatcher.OnF
     public static final String STATE_INCLUDE_INCOMPLETE = "include_incomplete";
     public static final String DOWNLOAD_IMAGES_TASK_KEY = "download_images_task";
     public static final String DOWNLOAD_IMAGES_TASK_GROUP = "download_images_task";
+    public static final String TAG = PrintDialog.class.getName();
     private Translator translator;
     private TargetTranslation mTargetTranslation;
     private Library library;
@@ -223,6 +228,17 @@ public class PrintDialog extends DialogFragment implements SimpleTaskWatcher.OnF
             }
         } else if(task instanceof PrintPDFTask) {
             if(((PrintPDFTask)task).isSuccess()) {
+
+                // copy to downloads folder
+                File downloadsDir = App.getPublicDownloadsDirectory();
+                if(downloadsDir.exists()) {
+                    try {
+                        FileUtilities.copyFile(mExportFile, new File(downloadsDir, mExportFile.getName()));
+                    } catch (IOException e) {
+                        Logger.e(TAG, "Failed to copy the PDF file", e);
+                    }
+                }
+
                 // send to print provider
                 Uri u = FileProvider.getUriForFile(App.context(), "com.door43.translationstudio.fileprovider", mExportFile);
                 Intent i = new Intent(Intent.ACTION_SEND);


### PR DESCRIPTION
Fix #1578 images are not printed even though requested.

Changes in this pull request:
- Modified hasImages() so partially downloaded zip is not considered an image. 
- Fixed path for images in PdfPrinter.addContent(). Removed 360px from path since the subfolder is not created.
- Now saves a copy of PDF file to downloads folder in case send fails (such as file too large to email).