### PR TITLE
Fix #1477 Add attribution of artwork to pdf output.

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
+++ b/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
@@ -427,16 +427,11 @@ public class PdfPrinter extends PdfPageEventHelper {
         // translate simple html to paragraphs
         String license = App.context().getResources().getString(R.string.license_pdf);
 
+        if(includeMedia) {
+            license += App.context().getResources().getString(R.string.artwork_attribution_pdf);
+        }
+
         license = license.replace("&#8226;", "\u2022");
-//        license = license.replace("<p>", "<br/>");
-//        license = license.replace("</p>", "<br/>");
-//        license = license.replace("<h2>", "<br/>");
-//        license = license.replace("</h2>", "<br/>");
-//        String[] lines = license.split("<br/>");
-//        for (String line : lines) {
-//            Paragraph paragraph = new Paragraph(line, bodyFont);
-//            document.add(paragraph);
-//        }
 
         mCurrentParagraph = null;
         parseHtml( document, license, 0);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -786,6 +786,12 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
 <br/><b>Use of trademarks:</b> unfoldingWord is a trademark of Distant Shores Media and may not be included on any derivative works created from this content. Unaltered content from <a href="http://unfoldingword.org" title="http://unfoldingword.org" >http://unfoldingword.org</a> must include the unfoldingWord logo when distributed to others. But if you alter the content in any way, you must remove the unfoldingWord logo before distributing your work.
 </p>]]>
     </string>
+    <string name="artwork_attribution_pdf">
+<![CDATA[
+<p><b>Attribution of artwork:</b> All images used in these stories are © Sweet Publishing (<a href="http://www.sweetpublishing.com" title="www.sweetpublishing.com" >www.sweetpublishing.com</a>) and are made available under a Creative Commons Attribution-Share Alike License (<a href="http://creativecommons.org/licenses/by-sa/3.0" title="http://creativecommons.org/licenses/by-sa/3.0" >http://creativecommons.org/licenses/by-sa/3.0</a>).
+<br/>
+</p>]]>
+    </string>
     <string name="questionnaire_title">Page <xliff:g example="1" id="page_num">%1$d</xliff:g> of <xliff:g example="10" id="page_count">%2$d</xliff:g></string>
     <string name="new_lang_api_upload_failure_title">New Language Error</string>
     <string name="new_lang_api_upload_failure">We could not save the answers to the New Language Questionnaire.  We will try again the next time you</string>


### PR DESCRIPTION
Fix #1477 Add attribution of artwork to pdf output when images are printed.

@neutrinog - quick fix.
