### PR TITLE
Fix QA issues #1563 app displays source translations before they are downloaded

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/newui/home/HomeActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/home/HomeActivity.java
@@ -660,7 +660,7 @@ public class HomeActivity extends BaseActivity implements SimpleTaskWatcher.OnFi
 
         Project project = App.getLibrary().getProject(targetTranslation.getProjectId(), "en");
         TargetLanguage language = App.getLibrary().getTargetLanguage(targetTranslation);
-        if(project == null || !App.getLibrary().projectHasSource(project.getId())) {
+        if(project == null) {
             // validate project source exists
             Snackbar snack = Snackbar.make(findViewById(android.R.id.content), R.string.missing_project, Snackbar.LENGTH_LONG);
             snack.setAction(R.string.download, new View.OnClickListener() {

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationAdapter.java
@@ -162,10 +162,6 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter  implements Mana
         DownloadSourceLanguageTask downloadTask = (DownloadSourceLanguageTask) task;
         Library library = App.getLibrary();
 
-        if (progressDialog != null) {
-            progressDialog.dismiss();
-        }
-
         if(downloadTask.isFinished() && downloadTask.getSuccess()) {
             boolean databaseChanged = false;
             String sourceLang = downloadTask.getSourceLanguageId();
@@ -175,21 +171,29 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter  implements Mana
                 for (int i = 0; i < getCount(); i++) {
                     ChooseSourceTranslationAdapter.ViewItem item = getItem(i);
                     if (item != null) {
-                        if((item.sourceTranslation != null) && sourceLang.equals(item.sourceTranslation.sourceLanguageSlug) && projectId.equals(item.sourceTranslation.projectSlug)) {
+                        if( item.sourceTranslation != null ) {
                             Resource resource = library.getResource(item.sourceTranslation);
                             if (resource != null) {
-                                item.downloaded = resource.isDownloaded();
-                                item.hasUpdates = resource.hasUpdates();
-                                databaseChanged = true;
+                                if(item.downloaded != resource.isDownloaded()) {
+                                    item.downloaded = resource.isDownloaded();
+                                    databaseChanged = true;
+                                }
+                                if(item.hasUpdates != resource.hasUpdates()) {
+                                    item.hasUpdates = resource.hasUpdates();
+                                    databaseChanged = true;
+                                }
                             } else {
                                 Logger.e(TAG, "Failed to get resource for " + item.sourceTranslation.getId());
                             }
-                            break;
                         }
                     } else {
                         Logger.e(TAG, "Failed to get SourceTranslation for " + item.id);
                     }
                 }
+            }
+
+            if (progressDialog != null) {
+                progressDialog.dismiss();
             }
 
             if(databaseChanged) { // refresh list in main loop

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationAdapter.java
@@ -106,6 +106,7 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter  implements Mana
         } else {
             select(position);
         }
+        sort();
     }
 
     /**
@@ -279,7 +280,7 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter  implements Mana
 
     @Override
     public int getViewTypeCount() {
-        return 3;
+        return 4;
     }
 
     /**

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationDialog.java
@@ -162,7 +162,8 @@ public class ChooseSourceTranslationDialog extends DialogFragment {
         Resource resource = mLibrary.getResource( sourceTranslation);
         if(resource != null) {
             boolean downloaded = resource.isDownloaded();
-            mAdapter.addItem(new ChooseSourceTranslationAdapter.ViewItem(title, sourceTranslation, selected, downloaded));
+            boolean hasUpdates = resource.hasUpdates();
+            mAdapter.addItem(new ChooseSourceTranslationAdapter.ViewItem(title, sourceTranslation, selected, downloaded, hasUpdates));
         } else {
             Logger.e(TAG, "Failed to get resource for " + sourceTranslation.getId());
         }

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ChooseSourceTranslationDialog.java
@@ -105,7 +105,6 @@ public class ChooseSourceTranslationDialog extends DialogFragment {
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 if(mAdapter.isSelectableItem(position)) {
                     mAdapter.doClickOnItem(position);
-                    mAdapter.sort();
                 }
             }
         });

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/TargetTranslationActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/TargetTranslationActivity.java
@@ -362,7 +362,7 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
      * method to see if searching is supported
      */
     public boolean isSearchSupported() {
-        if(mFragment != null) {
+        if(mFragment instanceof ViewModeFragment) {
             return ((ViewModeFragment) mFragment).isSearchSupported();
         }
         return false;

--- a/app/src/main/res/layout/fragment_select_source_translation_list_updatable_item.xml
+++ b/app/src/main/res/layout/fragment_select_source_translation_list_updatable_item.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal" android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingRight="16dp"
+    android:paddingLeft="16dp"
+    android:paddingTop="10dp"
+    android:paddingBottom="10dp">
+
+    <TextView
+        android:layout_gravity="center_vertical"
+        android:layout_width="wrap_content"
+        android:layout_weight="1"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/body"
+        android:textColor="@color/dark_primary_text"
+        android:text="English - Unlocked Literal Bible"
+        android:id="@+id/title" />
+
+    <ImageView
+        android:layout_gravity="center_vertical"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="16dp"
+        android:background="@drawable/ic_refresh_black_24dp"
+        android:id="@+id/download_resource" />
+
+    <ImageView
+        android:layout_gravity="center_vertical"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="16dp"
+        android:background="@drawable/ic_check_box_outline_blank_black_24dp"
+        android:id="@+id/checkBoxView" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -845,4 +845,5 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
     <string name="export_to_usfm">Export USFM to SD Card</string>
     <string name="export_failed">Export failed!</string>
     <string name="export_success">Export successful!\n\nExported file is at:\n<xliff:g example="/sd_card/downloads" id="file_path">%1$s</xliff:g></string>
+    <string name="update_source_language">Do you want to update \'<xliff:g example="Pig Latin" id="language">%1$s</xliff:g>\' from Online (requires internet)?</string>
 </resources>


### PR DESCRIPTION
Fixes QA questions in #1563 app displays source translations before they are downloaded

Changes in this pull request:
- Added support for updating languages.
- Removed check for missing sources on project on HomeActivity since they can now be individually downloaded in source language chooser.

@neutrinog 
