### PR TITLE
Fix #1608 cannot send feedback

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,7 +87,7 @@ dependencies {
 
     compile 'org.unfoldingword.tools:gogs-client:1.6.0'
     compile 'org.unfoldingword.tools:task-manager:1.5.0'
-    compile 'org.unfoldingword.tools:logger:1.3.1'
+    compile 'org.unfoldingword.tools:logger:2.0.0'
 
     compile project(':html-textview')
     compile project(':seekbarhint')

--- a/app/src/main/java/com/door43/translationstudio/App.java
+++ b/app/src/main/java/com/door43/translationstudio/App.java
@@ -83,12 +83,12 @@ public class App extends Application {
         super.onCreate();
         sInstance = this;
 
-        File dir = new File(App.getPublicDirectory(), "crashes");
-        Logger.registerGlobalExceptionHandler(dir);
-
         // configure logger
         int minLogLevel = Integer.parseInt(getUserPreferences().getString(SettingsActivity.KEY_PREF_LOGGING_LEVEL, getResources().getString(R.string.pref_default_logging_level)));
         configureLogger(minLogLevel);
+
+        File dir = new File(App.getPublicDirectory(), "crashes");
+        Logger.registerGlobalExceptionHandler(dir);
 
         // initialize default settings
         // NOTE: make sure to add any new preference files here in order to have their default values properly loaded.

--- a/app/src/main/java/com/door43/translationstudio/CrashReporterActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/CrashReporterActivity.java
@@ -158,7 +158,7 @@ public class CrashReporterActivity extends BaseActivity implements ManagedTask.O
             }
         });
 
-        if(task.getClass().getName().equals(CheckForLatestReleaseTask.class.getName())) {
+        if(task instanceof CheckForLatestReleaseTask) {
             CheckForLatestReleaseTask.Release release = ((CheckForLatestReleaseTask)task).getLatestRelease();
             if(release != null) {
                 // ask user if they would like to download updates
@@ -183,7 +183,7 @@ public class CrashReporterActivity extends BaseActivity implements ManagedTask.O
                 newTask.addOnFinishedListener(CrashReporterActivity.this);
                 TaskManager.addTask(newTask, UploadCrashReportTask.TASK_ID);
             }
-        } else if(task.getClass().getName().equals(UploadCrashReportTask.class.getName())) {
+        } else if(task instanceof UploadCrashReportTask) {
             openSplash();
         }
     }

--- a/app/src/main/java/com/door43/translationstudio/CrashReporterActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/CrashReporterActivity.java
@@ -184,7 +184,21 @@ public class CrashReporterActivity extends BaseActivity implements ManagedTask.O
                 TaskManager.addTask(newTask, UploadCrashReportTask.TASK_ID);
             }
         } else if(task instanceof UploadCrashReportTask) {
-            openSplash();
+            boolean success = ((UploadCrashReportTask) task).isSuccess();
+            if(success) {
+              openSplash();
+            } else { // upload failed
+                hand.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        new AlertDialog.Builder(CrashReporterActivity.this, R.style.AppTheme_Dialog)
+                                .setTitle(R.string.upload_failed)
+                                .setMessage(R.string.upload_crash_report_failed)
+                                .setPositiveButton(R.string.label_ok, null)
+                                .show();
+                    }
+                });
+            }
         }
     }
 

--- a/app/src/main/java/com/door43/translationstudio/newui/FeedbackDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/FeedbackDialog.java
@@ -133,6 +133,12 @@ public class FeedbackDialog extends DialogFragment implements ManagedTask.OnFini
         mLoadingLayout.setVisibility(View.VISIBLE);
     }
 
+    private void hideLoadingUI() {
+        mFormLayout.setVisibility(View.VISIBLE);
+        mControlsLayout.setVisibility(View.VISIBLE);
+        mLoadingLayout.setVisibility(View.GONE);
+    }
+
     @Override
     public void onTaskFinished(ManagedTask task) {
         TaskManager.clearTask(task);
@@ -160,10 +166,25 @@ public class FeedbackDialog extends DialogFragment implements ManagedTask.OnFini
             }
         } else if(task instanceof UploadBugReportTask) {
             boolean success = ((UploadBugReportTask) task).isSuccess();
-            Snackbar snack = Snackbar.make(getActivity().findViewById(android.R.id.content), success ? R.string.success : R.string.upload_failed_label, Snackbar.LENGTH_LONG);
-            ViewUtil.setSnackBarTextColor(snack, getResources().getColor(R.color.light_primary_text));
-            snack.show();
-            FeedbackDialog.this.dismiss();
+            if(success) {
+                Snackbar snack = Snackbar.make(getActivity().findViewById(android.R.id.content), success ? R.string.success : R.string.upload_failed_label, Snackbar.LENGTH_LONG);
+                ViewUtil.setSnackBarTextColor(snack, getResources().getColor(R.color.light_primary_text));
+                snack.show();
+                FeedbackDialog.this.dismiss();
+            } else { // upload failed
+                Handler hand = new Handler(Looper.getMainLooper());
+                hand.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        hideLoadingUI();
+                        new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
+                                .setTitle(R.string.upload_failed)
+                                .setMessage(R.string.upload_feedback_failed)
+                                .setPositiveButton(R.string.label_ok, null)
+                                .show();
+                    }
+                });
+            }
         }
     }
 

--- a/app/src/main/java/com/door43/translationstudio/newui/FeedbackDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/FeedbackDialog.java
@@ -137,7 +137,7 @@ public class FeedbackDialog extends DialogFragment implements ManagedTask.OnFini
     public void onTaskFinished(ManagedTask task) {
         TaskManager.clearTask(task);
 
-        if(task.getClass().getName().equals(CheckForLatestReleaseTask.class.getName())) {
+        if(task instanceof CheckForLatestReleaseTask) {
             CheckForLatestReleaseTask.Release release = ((CheckForLatestReleaseTask)task).getLatestRelease();
             if(release != null) {
                 mLatestRelease = release;
@@ -158,8 +158,9 @@ public class FeedbackDialog extends DialogFragment implements ManagedTask.OnFini
                     FeedbackDialog.this.dismiss();
                 }
             }
-        } else if(task.getClass().getName().equals(UploadBugReportTask.class.getName())) {
-            Snackbar snack = Snackbar.make(getActivity().findViewById(android.R.id.content), R.string.success, Snackbar.LENGTH_LONG);
+        } else if(task instanceof UploadBugReportTask) {
+            boolean success = ((UploadBugReportTask) task).isSuccess();
+            Snackbar snack = Snackbar.make(getActivity().findViewById(android.R.id.content), success ? R.string.success : R.string.upload_failed_label, Snackbar.LENGTH_LONG);
             ViewUtil.setSnackBarTextColor(snack, getResources().getColor(R.color.light_primary_text));
             snack.show();
             FeedbackDialog.this.dismiss();

--- a/app/src/main/java/com/door43/translationstudio/tasks/UploadBugReportTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/UploadBugReportTask.java
@@ -1,5 +1,6 @@
 package com.door43.translationstudio.tasks;
 
+import org.unfoldingword.tools.http.Request;
 import org.unfoldingword.tools.logger.GithubReporter;
 import org.unfoldingword.tools.logger.Logger;
 
@@ -17,13 +18,24 @@ import java.io.IOException;
 public class UploadBugReportTask extends ManagedTask {
     public static final String TASK_ID = "upload_bug_report_task";
     private final String mNotes;
+    private int mResponseCode = -1;
+
 
     public UploadBugReportTask(String notes) {
         mNotes = notes;
     }
 
+    /**
+     * determine if upload was success
+     * @return
+     */
+    public boolean isSuccess() {
+        return (mResponseCode >= 200) && (mResponseCode <= 202);
+    }
+
     @Override
     public void start() {
+        mResponseCode = -1;
         File logFile = Logger.getLogFile();
 
         // TRICKY: make sure the github_oauth2 token has been set
@@ -32,16 +44,25 @@ public class UploadBugReportTask extends ManagedTask {
 
         if(githubTokenIdentifier != 0) {
             GithubReporter reporter = new GithubReporter(App.context(), githubUrl, App.context().getResources().getString(githubTokenIdentifier));
-            reporter.reportBug(mNotes, logFile);
-
-            // empty the log
             try {
-                FileUtilities.writeStringToFile(logFile, "");
+                Request request = reporter.reportBug(mNotes, logFile);
+                mResponseCode = request.getResponseCode();
             } catch (IOException e) {
                 e.printStackTrace();
             }
 
-            Logger.i(this.getClass().getName(), "Submitted bug report");
+            if(!isSuccess()) {
+                Logger.e(this.getClass().getName(), "Failed to upload bug report.  Code: " + mResponseCode);
+            } else { // success
+                // empty the log
+                try {
+                    FileUtilities.writeStringToFile(logFile, "");
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                Logger.i(this.getClass().getName(), "Submitted bug report");
+            }
+
         } else if(githubTokenIdentifier == 0) {
             Logger.w(this.getClass().getName(), "the github oauth2 token is missing");
         }

--- a/app/src/main/java/com/door43/translationstudio/tasks/UploadBugReportTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/UploadBugReportTask.java
@@ -33,6 +33,14 @@ public class UploadBugReportTask extends ManagedTask {
         return (mResponseCode >= 200) && (mResponseCode <= 202);
     }
 
+    /**
+     * get response code from server
+     * @return
+     */
+    public int getResponseCode() {
+        return mResponseCode;
+    }
+
     @Override
     public void start() {
         mResponseCode = -1;
@@ -54,15 +62,14 @@ public class UploadBugReportTask extends ManagedTask {
             if(!isSuccess()) {
                 Logger.e(this.getClass().getName(), "Failed to upload bug report.  Code: " + mResponseCode);
             } else { // success
-                // empty the log
-                try {
-                    FileUtilities.writeStringToFile(logFile, "");
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
                 Logger.i(this.getClass().getName(), "Submitted bug report");
             }
 
+            try {
+                FileUtilities.writeStringToFile(logFile, "");
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         } else if(githubTokenIdentifier == 0) {
             Logger.w(this.getClass().getName(), "the github oauth2 token is missing");
         }

--- a/app/src/main/java/com/door43/translationstudio/tasks/UploadCrashReportTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/UploadCrashReportTask.java
@@ -33,6 +33,14 @@ public class UploadCrashReportTask extends ManagedTask {
         return (mResponseCode >= 200) && (mResponseCode <= 202);
     }
 
+    /**
+     * get response code from server
+     * @return
+     */
+    public int getResponseCode() {
+        return mResponseCode;
+    }
+
     @Override
     public void start() {
         mResponseCode = -1;

--- a/app/src/main/java/com/door43/translationstudio/tasks/UploadCrashReportTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/UploadCrashReportTask.java
@@ -1,5 +1,6 @@
 package com.door43.translationstudio.tasks;
 
+import org.unfoldingword.tools.http.Request;
 import org.unfoldingword.tools.logger.GithubReporter;
 
 import com.door43.translationstudio.App;
@@ -9,6 +10,7 @@ import org.unfoldingword.tools.logger.Logger;
 import org.unfoldingword.tools.taskmanager.ManagedTask;
 
 import java.io.File;
+import java.io.IOException;
 
 /**
  * This task submits the latest crash report to github
@@ -17,13 +19,23 @@ public class UploadCrashReportTask extends ManagedTask {
     public static final String TASK_ID = "upload_crash_report_task";
     private final String mMessage;
     private int mMaxProgress = 100;
+    private int mResponseCode = -1;
 
     public UploadCrashReportTask(String message) {
         mMessage = message;
     }
 
+    /**
+     * determine if upload was success
+     * @return
+     */
+    public boolean isSuccess() {
+        return (mResponseCode >= 200) && (mResponseCode <= 202);
+    }
+
     @Override
     public void start() {
+        mResponseCode = -1;
         File logFile = new File(App.getPublicDirectory(), "log.txt");
         int githubTokenIdentifier = App.context().getResources().getIdentifier("github_oauth2", "string", App.context().getPackageName());
         String githubUrl = App.context().getResources().getString(R.string.github_bug_report_repo);
@@ -33,11 +45,20 @@ public class UploadCrashReportTask extends ManagedTask {
             GithubReporter reporter = new GithubReporter(App.context(), githubUrl, App.context().getResources().getString(githubTokenIdentifier));
             File[] stacktraces = Logger.listStacktraces();
             if (stacktraces.length > 0) {
-                // upload most recent stacktrace
-                reporter.reportCrash(mMessage, stacktraces[0], logFile);
+                try {
+                    // upload most recent stacktrace
+                    Request request = reporter.reportCrash(mMessage, stacktraces[0], logFile);
+                    mResponseCode = request.getResponseCode();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
 
-                // empty the log
-                Logger.flush();
+                if(!isSuccess()) {
+                    Logger.e(UploadCrashReportTask.class.getSimpleName(), "Failed to upload crash report.  Code: " + mResponseCode);
+                } else { // success
+                    // empty the log
+                    Logger.flush();
+                }
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -880,4 +880,6 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
     <string name="import_merge_conflict">Merge conflict on Import - Click OK to resolve</string>
     <string name="label_change">change</string>
     <string name="upload_failed_label">Upload Failed!</string>
+    <string name="upload_feedback_failed">Upload of feedback failed</string>
+    <string name="upload_crash_report_failed">Upload of crash report failed</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -879,4 +879,5 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
     <string name="merge_conflict_title">Merge Conflict</string>
     <string name="import_merge_conflict">Merge conflict on Import - Click OK to resolve</string>
     <string name="label_change">change</string>
+    <string name="upload_failed_label">Upload Failed!</string>
 </resources>


### PR DESCRIPTION
Fix #1608 cannot send feedback

Changes in this pull request:
- Updated logger to 2.0.0 which fixes https upload error and adds detection of response codes.
- Added capture and checking of upload report error codes in UploadBugReportTask and UploadCrashReportTask.   
- Fixed detection of crash reports.  
- Added detection of upload failed for crash reports and feedback.  Failures now have popup dialog shown to user.

@neutrinog - ready for review.