### PR TITLE
Fix #1615 Remove the "Export USFM to SD Card" for OBS projects 

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/newui/BackupDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/BackupDialog.java
@@ -187,6 +187,12 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
             }
         });
 
+        if(targetTranslation.isObsProject()) {
+            LinearLayout exportToUsfmSeparator = (LinearLayout)v.findViewById(R.id.export_to_usfm_separator);
+            exportToUsfmSeparator.setVisibility(View.GONE);
+            exportToUsfmButton.setVisibility(View.GONE);
+        }
+
         backupToAppButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/app/src/main/res/layout/dialog_backup.xml
+++ b/app/src/main/res/layout/dialog_backup.xml
@@ -115,6 +115,7 @@
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/export_to_usfm_separator"
                 android:layout_width="match_parent"
                 android:layout_height="1px"
                 android:background="@color/list_separator" />


### PR DESCRIPTION
Fix #1615 Remove the "Export USFM to SD Card" for OBS projects 

Changes in this pull request:
- Remove the "Export USFM to SD Card" backup option for OBS projects 

@neutrinog - ready for review.