### PR TITLE
Fix #1549 provide font settings for source translation and target translation

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/SettingsActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/SettingsActivity.java
@@ -69,7 +69,9 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
     public static final String KEY_PREF_MEDIA_SERVER = "media_server";
 //    public static final String KEY_PREF_EXPORT_FORMAT = "export_format";
     public static final String KEY_PREF_TRANSLATION_TYPEFACE = "translation_typeface";
-    public static final String KEY_PREF_TYPEFACE_SIZE = "typeface_size";
+    public static final String KEY_PREF_TRANSLATION_TYPEFACE_SIZE = "typeface_size";
+    public static final String KEY_PREF_SOURCE_TYPEFACE = "source_typeface";
+    public static final String KEY_PREF_SOURCE_TYPEFACE_SIZE = "source_typeface_size";
 //    public static final String KEY_PREF_HIGHLIGHT_KEY_TERMS = "highlight_key_terms";
 //    public static final String KEY_PREF_ADVANCED_SETTINGS = "advanced_settings";
     public static final String KEY_PREF_LOGGING_LEVEL = "logging_level";
@@ -185,6 +187,15 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
         pref.setEntryValues(entryValues.toArray(new CharSequence[entryValues.size()]));
         bindPreferenceSummaryToValue(pref);
 
+        bindPreferenceSummaryToValue(findPreference(KEY_PREF_TRANSLATION_TYPEFACE_SIZE));
+
+        ListPreference fontSourcePref = (ListPreference)findPreference(KEY_PREF_SOURCE_TYPEFACE);
+        fontSourcePref.setEntries(entries.toArray(new CharSequence[entries.size()]));
+        fontSourcePref.setEntryValues(entryValues.toArray(new CharSequence[entryValues.size()]));
+        bindPreferenceSummaryToValue(fontSourcePref);
+
+        bindPreferenceSummaryToValue(findPreference(KEY_PREF_SOURCE_TYPEFACE_SIZE));
+
         // Add 'sharing' preferences, and a corresponding header.
 //        PreferenceCategory preferenceHeader = new PreferenceCategory(this);
 //        preferenceHeader.setTitle(R.string.pref_header_sharing);
@@ -229,7 +240,6 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_MEDIA_SERVER));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_LOGGING_LEVEL));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_BACKUP_INTERVAL));
-        bindPreferenceSummaryToValue(findPreference(KEY_PREF_TYPEFACE_SIZE));
 
         final Preference appVersionPref = findPreference("app_version");
         try {
@@ -450,7 +460,14 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
             fontPref.setEntryValues(entryValues.toArray(new CharSequence[entryValues.size()]));
             bindPreferenceSummaryToValue(fontPref);
 
-            bindPreferenceSummaryToValue(findPreference(KEY_PREF_TYPEFACE_SIZE));
+            bindPreferenceSummaryToValue(findPreference(KEY_PREF_TRANSLATION_TYPEFACE_SIZE));
+
+            ListPreference fontSourcePref = (ListPreference)findPreference(KEY_PREF_SOURCE_TYPEFACE);
+            fontSourcePref.setEntries(entries.toArray(new CharSequence[entries.size()]));
+            fontSourcePref.setEntryValues(entryValues.toArray(new CharSequence[entryValues.size()]));
+            bindPreferenceSummaryToValue(fontSourcePref);
+
+            bindPreferenceSummaryToValue(findPreference(KEY_PREF_SOURCE_TYPEFACE_SIZE));
 
             final Preference appVersionPref = findPreference("app_version");
             try {

--- a/app/src/main/java/com/door43/translationstudio/core/Typography.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Typography.java
@@ -10,23 +10,25 @@ import android.widget.TextView;
 import com.door43.translationstudio.R;
 import com.door43.translationstudio.SettingsActivity;
 
-import java.io.File;
-
 /**
  * Created by joel on 9/11/2015.
  */
 public class Typography {
 
+    public static final eRenderType RENDER_SOURCE = eRenderType.SOURCE;
+    public static final eRenderType RENDER_TRANSLATION = eRenderType.TRANSLATION;
+
     /**
      * Formats the text in the text view using the users preferences
      * @param context
+     * @param renderType
      * @param view
-     * @param langaugeCode the spoken language of the text
+     * @param languageCode the spoken language of the text
      * @param direction the reading direction of the text
      */
-    public static void format(Context context, TextView view, String langaugeCode, LanguageDirection direction) {
-        Typeface typeface = getTypeface(context, langaugeCode, direction);
-        float fontSize = getFontSize(context);
+    public static void format(Context context, eRenderType renderType, TextView view, String languageCode, LanguageDirection direction) {
+        Typeface typeface = getTypeface(context, renderType, languageCode, direction);
+        float fontSize = getFontSize(context, renderType);
 
         view.setTypeface(typeface, 0);
         view.setTextSize(TypedValue.COMPLEX_UNIT_SP, fontSize);
@@ -37,13 +39,14 @@ public class Typography {
      * Titles are a little larger than normal text and bold
      *
      * @param context
+     * @param renderType
      * @param view
-     * @param langaugeCode the spoken language of the text
+     * @param languageCode the spoken language of the text
      * @param direction the reading direction of the text
      */
-    public static void formatTitle(Context context, TextView view, String langaugeCode, LanguageDirection direction) {
-        Typeface typeface = getTypeface(context, langaugeCode, direction);
-        float fontSize = getFontSize(context) * 1.3f;
+    public static void formatTitle(Context context, eRenderType renderType, TextView view, String languageCode, LanguageDirection direction) {
+        Typeface typeface = getTypeface(context, renderType, languageCode, direction);
+        float fontSize = getFontSize(context, renderType) * 1.3f;
 
         view.setTypeface(typeface, Typeface.BOLD);
         view.setTextSize(TypedValue.COMPLEX_UNIT_SP, fontSize);
@@ -54,13 +57,14 @@ public class Typography {
      * Sub text is a little smaller than normal text
      *
      * @param context
+     * @param renderType
      * @param view
-     * @param langaugeCode the spoken language of the text
+     * @param languageCode the spoken language of the text
      * @param direction the reading direction of the text
      */
-    public static void formatSub(Context context, TextView view, String langaugeCode, LanguageDirection direction) {
-        Typeface typeface = getTypeface(context, langaugeCode, direction);
-        float fontSize = getFontSize(context) * .7f;
+    public static void formatSub(Context context, eRenderType renderType, TextView view, String languageCode, LanguageDirection direction) {
+        Typeface typeface = getTypeface(context, renderType, languageCode, direction);
+        float fontSize = getFontSize(context, renderType) * .7f;
 
         view.setTypeface(typeface, 0);
         view.setTextSize(TypedValue.COMPLEX_UNIT_SP, fontSize);
@@ -69,12 +73,13 @@ public class Typography {
     /**
      * Returns a subset of user preferences (currently, just the size) as a CSS style tag.
      * @param context
+     * @param renderType
      * @return Valid HTML, for prepending to unstyled HTML text
      */
-    public static CharSequence getStyle(Context context) {
+    public static CharSequence getStyle(Context context, eRenderType renderType) {
         return "<style type=\"text/css\">"
                 + "body {"
-                + "  font-size: " + getFontSize(context) + ";"
+                + "  font-size: " + getFontSize(context, renderType) + ";"
                 + "}"
                 + "</style>";
     }
@@ -82,36 +87,42 @@ public class Typography {
     /**
      * Returns the font size chosen by the user
      * @param context
+     * @param renderType
      * @return
      */
-    public static float getFontSize(Context context) {
+    public static float getFontSize(Context context, eRenderType renderType) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        return Integer.parseInt(prefs.getString(SettingsActivity.KEY_PREF_TYPEFACE_SIZE, context.getResources().getString(R.string.pref_default_typeface_size)));
+        String typefaceSize = (renderType == RENDER_SOURCE) ? SettingsActivity.KEY_PREF_SOURCE_TYPEFACE_SIZE :  SettingsActivity.KEY_PREF_TRANSLATION_TYPEFACE_SIZE;
+        return Integer.parseInt(prefs.getString(typefaceSize, context.getResources().getString(R.string.pref_default_typeface_size)));
     }
 
     /**
      * Returns the path to the font asset
      * @param context
+     * @param renderType
      * @return
      */
-    public static String getAssetPath(Context context) {
+    public static String getAssetPath(Context context, eRenderType renderType) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        String fontName = prefs.getString(SettingsActivity.KEY_PREF_TRANSLATION_TYPEFACE, context.getResources().getString(R.string.pref_default_translation_typeface));
+        String selectedTypeface = (renderType == RENDER_SOURCE) ? SettingsActivity.KEY_PREF_SOURCE_TYPEFACE : SettingsActivity.KEY_PREF_TRANSLATION_TYPEFACE;
+        String fontName = prefs.getString(selectedTypeface, context.getResources().getString(R.string.pref_default_translation_typeface));
         return "assets/fonts/" + fontName;
     }
 
     /**
      * Returns the typeface chosen by the user
      * @param context
+     * @param renderType
      * @param languageCode the spoken language
      * @param direction the reading direction
      * @return
      */
-    public static Typeface getTypeface(Context context, String languageCode, LanguageDirection direction) {
+    public static Typeface getTypeface(Context context, eRenderType renderType, String languageCode, LanguageDirection direction) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        String fontName = prefs.getString(SettingsActivity.KEY_PREF_TRANSLATION_TYPEFACE, context.getResources().getString(R.string.pref_default_translation_typeface));
+        String selectedTypeface = (renderType == RENDER_SOURCE) ? SettingsActivity.KEY_PREF_SOURCE_TYPEFACE : SettingsActivity.KEY_PREF_TRANSLATION_TYPEFACE;
+        String fontName = prefs.getString(selectedTypeface, context.getResources().getString(R.string.pref_default_translation_typeface));
 
-        // TODO: provide grahite support
+        // TODO: provide graphite support
 //        File fontFile = new File(context.getCacheDir(), "assets/fonts" + fontName);
 //        if(!fontFile.exists()) {
 //            fontFile.getParentFile().mkdirs();
@@ -146,5 +157,10 @@ public class Typography {
             e.printStackTrace();
         }
         return typeface;
+    }
+
+    public enum eRenderType {
+        SOURCE,
+        TRANSLATION
     }
 }

--- a/app/src/main/java/com/door43/translationstudio/core/Typography.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Typography.java
@@ -15,20 +15,17 @@ import com.door43.translationstudio.SettingsActivity;
  */
 public class Typography {
 
-    public static final eRenderType RENDER_SOURCE = eRenderType.SOURCE;
-    public static final eRenderType RENDER_TRANSLATION = eRenderType.TRANSLATION;
-
     /**
      * Formats the text in the text view using the users preferences
      * @param context
-     * @param renderType
+     * @param translationType
      * @param view
      * @param languageCode the spoken language of the text
      * @param direction the reading direction of the text
      */
-    public static void format(Context context, eRenderType renderType, TextView view, String languageCode, LanguageDirection direction) {
-        Typeface typeface = getTypeface(context, renderType, languageCode, direction);
-        float fontSize = getFontSize(context, renderType);
+    public static void format(Context context, TranslationType translationType, TextView view, String languageCode, LanguageDirection direction) {
+        Typeface typeface = getTypeface(context, translationType, languageCode, direction);
+        float fontSize = getFontSize(context, translationType);
 
         view.setTypeface(typeface, 0);
         view.setTextSize(TypedValue.COMPLEX_UNIT_SP, fontSize);
@@ -39,14 +36,14 @@ public class Typography {
      * Titles are a little larger than normal text and bold
      *
      * @param context
-     * @param renderType
+     * @param translationType
      * @param view
      * @param languageCode the spoken language of the text
      * @param direction the reading direction of the text
      */
-    public static void formatTitle(Context context, eRenderType renderType, TextView view, String languageCode, LanguageDirection direction) {
-        Typeface typeface = getTypeface(context, renderType, languageCode, direction);
-        float fontSize = getFontSize(context, renderType) * 1.3f;
+    public static void formatTitle(Context context, TranslationType translationType, TextView view, String languageCode, LanguageDirection direction) {
+        Typeface typeface = getTypeface(context, translationType, languageCode, direction);
+        float fontSize = getFontSize(context, translationType) * 1.3f;
 
         view.setTypeface(typeface, Typeface.BOLD);
         view.setTextSize(TypedValue.COMPLEX_UNIT_SP, fontSize);
@@ -57,14 +54,14 @@ public class Typography {
      * Sub text is a little smaller than normal text
      *
      * @param context
-     * @param renderType
+     * @param translationType
      * @param view
      * @param languageCode the spoken language of the text
      * @param direction the reading direction of the text
      */
-    public static void formatSub(Context context, eRenderType renderType, TextView view, String languageCode, LanguageDirection direction) {
-        Typeface typeface = getTypeface(context, renderType, languageCode, direction);
-        float fontSize = getFontSize(context, renderType) * .7f;
+    public static void formatSub(Context context, TranslationType translationType, TextView view, String languageCode, LanguageDirection direction) {
+        Typeface typeface = getTypeface(context, translationType, languageCode, direction);
+        float fontSize = getFontSize(context, translationType) * .7f;
 
         view.setTypeface(typeface, 0);
         view.setTextSize(TypedValue.COMPLEX_UNIT_SP, fontSize);
@@ -73,13 +70,13 @@ public class Typography {
     /**
      * Returns a subset of user preferences (currently, just the size) as a CSS style tag.
      * @param context
-     * @param renderType
+     * @param translationType
      * @return Valid HTML, for prepending to unstyled HTML text
      */
-    public static CharSequence getStyle(Context context, eRenderType renderType) {
+    public static CharSequence getStyle(Context context, TranslationType translationType) {
         return "<style type=\"text/css\">"
                 + "body {"
-                + "  font-size: " + getFontSize(context, renderType) + ";"
+                + "  font-size: " + getFontSize(context, translationType) + ";"
                 + "}"
                 + "</style>";
     }
@@ -87,24 +84,24 @@ public class Typography {
     /**
      * Returns the font size chosen by the user
      * @param context
-     * @param renderType
+     * @param translationType
      * @return
      */
-    public static float getFontSize(Context context, eRenderType renderType) {
+    public static float getFontSize(Context context, TranslationType translationType) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        String typefaceSize = (renderType == RENDER_SOURCE) ? SettingsActivity.KEY_PREF_SOURCE_TYPEFACE_SIZE :  SettingsActivity.KEY_PREF_TRANSLATION_TYPEFACE_SIZE;
+        String typefaceSize = (translationType == TranslationType.SOURCE) ? SettingsActivity.KEY_PREF_SOURCE_TYPEFACE_SIZE :  SettingsActivity.KEY_PREF_TRANSLATION_TYPEFACE_SIZE;
         return Integer.parseInt(prefs.getString(typefaceSize, context.getResources().getString(R.string.pref_default_typeface_size)));
     }
 
     /**
      * Returns the path to the font asset
      * @param context
-     * @param renderType
+     * @param translationType
      * @return
      */
-    public static String getAssetPath(Context context, eRenderType renderType) {
+    public static String getAssetPath(Context context, TranslationType translationType) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        String selectedTypeface = (renderType == RENDER_SOURCE) ? SettingsActivity.KEY_PREF_SOURCE_TYPEFACE : SettingsActivity.KEY_PREF_TRANSLATION_TYPEFACE;
+        String selectedTypeface = (translationType == TranslationType.SOURCE) ? SettingsActivity.KEY_PREF_SOURCE_TYPEFACE : SettingsActivity.KEY_PREF_TRANSLATION_TYPEFACE;
         String fontName = prefs.getString(selectedTypeface, context.getResources().getString(R.string.pref_default_translation_typeface));
         return "assets/fonts/" + fontName;
     }
@@ -112,14 +109,14 @@ public class Typography {
     /**
      * Returns the typeface chosen by the user
      * @param context
-     * @param renderType
+     * @param translationType
      * @param languageCode the spoken language
      * @param direction the reading direction
      * @return
      */
-    public static Typeface getTypeface(Context context, eRenderType renderType, String languageCode, LanguageDirection direction) {
+    public static Typeface getTypeface(Context context, TranslationType translationType, String languageCode, LanguageDirection direction) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-        String selectedTypeface = (renderType == RENDER_SOURCE) ? SettingsActivity.KEY_PREF_SOURCE_TYPEFACE : SettingsActivity.KEY_PREF_TRANSLATION_TYPEFACE;
+        String selectedTypeface = (translationType == TranslationType.SOURCE) ? SettingsActivity.KEY_PREF_SOURCE_TYPEFACE : SettingsActivity.KEY_PREF_TRANSLATION_TYPEFACE;
         String fontName = prefs.getString(selectedTypeface, context.getResources().getString(R.string.pref_default_translation_typeface));
 
         // TODO: provide graphite support
@@ -159,7 +156,7 @@ public class Typography {
         return typeface;
     }
 
-    public enum eRenderType {
+    public enum TranslationType {
         SOURCE,
         TRANSLATION
     }

--- a/app/src/main/java/com/door43/translationstudio/newui/draft/DraftAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/draft/DraftAdapter.java
@@ -154,9 +154,9 @@ public class DraftAdapter extends RecyclerView.Adapter<DraftAdapter.ViewHolder> 
         // set up fonts
         if(holder.mLayoutBuildNumber != mLayoutBuildNumber) {
             holder.mLayoutBuildNumber = mLayoutBuildNumber;
-            Typography.formatTitle(mContext, Typography.RENDER_SOURCE, holder.mSourceHeading, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.formatTitle(mContext, Typography.RENDER_SOURCE, holder.mSourceTitle, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.format(mContext, Typography.RENDER_SOURCE, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.formatTitle(mContext, Typography.TranslationType.SOURCE, holder.mSourceHeading, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.formatTitle(mContext, Typography.TranslationType.SOURCE, holder.mSourceTitle, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.format(mContext, Typography.TranslationType.SOURCE, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
         }
     }
 

--- a/app/src/main/java/com/door43/translationstudio/newui/draft/DraftAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/draft/DraftAdapter.java
@@ -154,9 +154,9 @@ public class DraftAdapter extends RecyclerView.Adapter<DraftAdapter.ViewHolder> 
         // set up fonts
         if(holder.mLayoutBuildNumber != mLayoutBuildNumber) {
             holder.mLayoutBuildNumber = mLayoutBuildNumber;
-            Typography.formatTitle(mContext, holder.mSourceHeading, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.formatTitle(mContext, holder.mSourceTitle, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.format(mContext, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.formatTitle(mContext, Typography.RENDER_SOURCE, holder.mSourceHeading, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.formatTitle(mContext, Typography.RENDER_SOURCE, holder.mSourceTitle, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.format(mContext, Typography.RENDER_SOURCE, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
         }
     }
 

--- a/app/src/main/java/com/door43/translationstudio/newui/library/ServerLibraryDetailFragment.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/library/ServerLibraryDetailFragment.java
@@ -138,8 +138,8 @@ public class ServerLibraryDetailFragment extends BaseFragment implements Managed
 
             // fonts
             SourceLanguage fontSourceLanguage = mServerLibrary.getSourceLanguage(mProject.getId(), mProject.sourceLanguageId);
-            Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, mHolder.mProjectDescription, fontSourceLanguage.getId(), fontSourceLanguage.getDirection());
-            Typography.formatTitle(getActivity(), Typography.RENDER_SOURCE, mHolder.mProjectTitle, fontSourceLanguage.getId(), fontSourceLanguage.getDirection());
+            Typography.formatSub(getActivity(), Typography.TranslationType.SOURCE, mHolder.mProjectDescription, fontSourceLanguage.getId(), fontSourceLanguage.getDirection());
+            Typography.formatTitle(getActivity(), Typography.TranslationType.SOURCE, mHolder.mProjectTitle, fontSourceLanguage.getId(), fontSourceLanguage.getDirection());
 
             // custom project icon
             if (mImagePath == null) {

--- a/app/src/main/java/com/door43/translationstudio/newui/library/ServerLibraryDetailFragment.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/library/ServerLibraryDetailFragment.java
@@ -138,8 +138,8 @@ public class ServerLibraryDetailFragment extends BaseFragment implements Managed
 
             // fonts
             SourceLanguage fontSourceLanguage = mServerLibrary.getSourceLanguage(mProject.getId(), mProject.sourceLanguageId);
-            Typography.formatSub(getActivity(), mHolder.mProjectDescription, fontSourceLanguage.getId(), fontSourceLanguage.getDirection());
-            Typography.formatTitle(getActivity(), mHolder.mProjectTitle, fontSourceLanguage.getId(), fontSourceLanguage.getDirection());
+            Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, mHolder.mProjectDescription, fontSourceLanguage.getId(), fontSourceLanguage.getDirection());
+            Typography.formatTitle(getActivity(), Typography.RENDER_SOURCE, mHolder.mProjectTitle, fontSourceLanguage.getId(), fontSourceLanguage.getDirection());
 
             // custom project icon
             if (mImagePath == null) {

--- a/app/src/main/java/com/door43/translationstudio/newui/library/ServerLibraryLanguageAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/library/ServerLibraryLanguageAdapter.java
@@ -95,7 +95,7 @@ public class ServerLibraryLanguageAdapter extends BaseAdapter {
         // name
         holder.mName.setText(getItem(position).sourceLanguage.name);
         holder.mCode.setText(getItem(position).sourceLanguage.code);
-        Typography.format(mContext, Typography.RENDER_SOURCE, holder.mName, getItem(position).sourceLanguage.getId(), getItem(position).sourceLanguage.direction);
+        Typography.format(mContext, Typography.TranslationType.SOURCE, holder.mName, getItem(position).sourceLanguage.getId(), getItem(position).sourceLanguage.direction);
 
         // progress
         holder.mProgressBar.setVisibility(View.GONE);

--- a/app/src/main/java/com/door43/translationstudio/newui/library/ServerLibraryLanguageAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/library/ServerLibraryLanguageAdapter.java
@@ -95,7 +95,7 @@ public class ServerLibraryLanguageAdapter extends BaseAdapter {
         // name
         holder.mName.setText(getItem(position).sourceLanguage.name);
         holder.mCode.setText(getItem(position).sourceLanguage.code);
-        Typography.format(mContext, holder.mName, getItem(position).sourceLanguage.getId(), getItem(position).sourceLanguage.direction);
+        Typography.format(mContext, Typography.RENDER_SOURCE, holder.mName, getItem(position).sourceLanguage.getId(), getItem(position).sourceLanguage.direction);
 
         // progress
         holder.mProgressBar.setVisibility(View.GONE);

--- a/app/src/main/java/com/door43/translationstudio/newui/publish/ValidationAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/publish/ValidationAdapter.java
@@ -75,7 +75,7 @@ public class ValidationAdapter extends RecyclerView.Adapter<ValidationAdapter.Vi
 
             // title
             holder.mTitle.setText(item.getTitle());
-            Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mTitle, item.getTitleLanguage().getId(), item.getTitleLanguage().getDirection());
+            Typography.format(mContext, Typography.TranslationType.TRANSLATION, holder.mTitle, item.getTitleLanguage().getId(), item.getTitleLanguage().getDirection());
 
             // icon
             if (item.isValid()) {
@@ -114,7 +114,7 @@ public class ValidationAdapter extends RecyclerView.Adapter<ValidationAdapter.Vi
                     renderedText[position] = renderingGroup.start();
                 }
                 holder.mBody.setText(renderedText[position]);
-                Typography.formatSub(mContext, Typography.RENDER_TRANSLATION, holder.mBody, item.getBodyLanguage().getId(), item.getBodyLanguage().getDirection());
+                Typography.formatSub(mContext, Typography.TranslationType.TRANSLATION, holder.mBody, item.getBodyLanguage().getId(), item.getBodyLanguage().getDirection());
             } else {
                 holder.mBody.setVisibility(View.GONE);
                 holder.mReviewButton.setVisibility(View.GONE);

--- a/app/src/main/java/com/door43/translationstudio/newui/publish/ValidationAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/publish/ValidationAdapter.java
@@ -75,7 +75,7 @@ public class ValidationAdapter extends RecyclerView.Adapter<ValidationAdapter.Vi
 
             // title
             holder.mTitle.setText(item.getTitle());
-            Typography.format(mContext, holder.mTitle, item.getTitleLanguage().getId(), item.getTitleLanguage().getDirection());
+            Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mTitle, item.getTitleLanguage().getId(), item.getTitleLanguage().getDirection());
 
             // icon
             if (item.isValid()) {
@@ -114,7 +114,7 @@ public class ValidationAdapter extends RecyclerView.Adapter<ValidationAdapter.Vi
                     renderedText[position] = renderingGroup.start();
                 }
                 holder.mBody.setText(renderedText[position]);
-                Typography.formatSub(mContext, holder.mBody, item.getBodyLanguage().getId(), item.getBodyLanguage().getDirection());
+                Typography.formatSub(mContext, Typography.RENDER_TRANSLATION, holder.mBody, item.getBodyLanguage().getId(), item.getBodyLanguage().getDirection());
             } else {
                 holder.mBody.setVisibility(View.GONE);
                 holder.mReviewButton.setVisibility(View.GONE);

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ChunkModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ChunkModeAdapter.java
@@ -424,10 +424,10 @@ public class ChunkModeAdapter extends ViewModeAdapter<ChunkModeAdapter.ViewHolde
         // set up fonts
         if(holder.mLayoutBuildNumber != mLayoutBuildNumber) {
             holder.mLayoutBuildNumber = mLayoutBuildNumber;
-            Typography.formatSub(mContext, Typography.RENDER_SOURCE, holder.mSourceTitle, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.format(mContext, Typography.RENDER_SOURCE, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.formatSub(mContext, Typography.RENDER_TRANSLATION, holder.mTargetTitle, mTargetLanguage.getId(), mTargetLanguage.getDirection());
-            Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mTargetBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+            Typography.formatSub(mContext, Typography.TranslationType.SOURCE, holder.mSourceTitle, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.format(mContext, Typography.TranslationType.SOURCE, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.formatSub(mContext, Typography.TranslationType.TRANSLATION, holder.mTargetTitle, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+            Typography.format(mContext, Typography.TranslationType.TRANSLATION, holder.mTargetBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
         }
 
         ViewUtil.makeLinksClickable(holder.mSourceBody);

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ChunkModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ChunkModeAdapter.java
@@ -424,10 +424,10 @@ public class ChunkModeAdapter extends ViewModeAdapter<ChunkModeAdapter.ViewHolde
         // set up fonts
         if(holder.mLayoutBuildNumber != mLayoutBuildNumber) {
             holder.mLayoutBuildNumber = mLayoutBuildNumber;
-            Typography.formatSub(mContext, holder.mSourceTitle, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.format(mContext, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.formatSub(mContext, holder.mTargetTitle, mTargetLanguage.getId(), mTargetLanguage.getDirection());
-            Typography.format(mContext, holder.mTargetBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+            Typography.formatSub(mContext, Typography.RENDER_SOURCE, holder.mSourceTitle, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.format(mContext, Typography.RENDER_SOURCE, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.formatSub(mContext, Typography.RENDER_TRANSLATION, holder.mTargetTitle, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+            Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mTargetBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
         }
 
         ViewUtil.makeLinksClickable(holder.mSourceBody);

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReadModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReadModeAdapter.java
@@ -442,11 +442,11 @@ public class ReadModeAdapter extends ViewModeAdapter<ReadModeAdapter.ViewHolder>
         // set up fonts
         if(holder.mLayoutBuildNumber != mLayoutBuildNumber) {
             holder.mLayoutBuildNumber = mLayoutBuildNumber;
-            Typography.formatTitle(mContext, Typography.RENDER_SOURCE, holder.mSourceHeading, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.formatTitle(mContext, Typography.RENDER_SOURCE, holder.mSourceTitle, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.format(mContext, Typography.RENDER_SOURCE, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.formatTitle(mContext, Typography.RENDER_TRANSLATION, holder.mTargetTitle, mTargetLanguage.getId(), mTargetLanguage.getDirection());
-            Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mTargetBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+            Typography.formatTitle(mContext, Typography.TranslationType.SOURCE, holder.mSourceHeading, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.formatTitle(mContext, Typography.TranslationType.SOURCE, holder.mSourceTitle, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.format(mContext, Typography.TranslationType.SOURCE, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.formatTitle(mContext, Typography.TranslationType.TRANSLATION, holder.mTargetTitle, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+            Typography.format(mContext, Typography.TranslationType.TRANSLATION, holder.mTargetBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
         }
     }
 

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReadModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReadModeAdapter.java
@@ -442,11 +442,11 @@ public class ReadModeAdapter extends ViewModeAdapter<ReadModeAdapter.ViewHolder>
         // set up fonts
         if(holder.mLayoutBuildNumber != mLayoutBuildNumber) {
             holder.mLayoutBuildNumber = mLayoutBuildNumber;
-            Typography.formatTitle(mContext, holder.mSourceHeading, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.formatTitle(mContext, holder.mSourceTitle, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.format(mContext, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.formatTitle(mContext, holder.mTargetTitle, mTargetLanguage.getId(), mTargetLanguage.getDirection());
-            Typography.format(mContext, holder.mTargetBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+            Typography.formatTitle(mContext, Typography.RENDER_SOURCE, holder.mSourceHeading, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.formatTitle(mContext, Typography.RENDER_SOURCE, holder.mSourceTitle, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.format(mContext, Typography.RENDER_SOURCE, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.formatTitle(mContext, Typography.RENDER_TRANSLATION, holder.mTargetTitle, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+            Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mTargetBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
         }
     }
 

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
@@ -427,15 +427,15 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
         // set up fonts
         if(holder.mLayoutBuildNumber != mLayoutBuildNumber) {
             holder.mLayoutBuildNumber = mLayoutBuildNumber;
-            Typography.format(mContext, Typography.RENDER_SOURCE, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.formatSub(mContext, Typography.RENDER_TRANSLATION, holder.mTargetTitle, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+            Typography.format(mContext, Typography.TranslationType.SOURCE, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.formatSub(mContext, Typography.TranslationType.TRANSLATION, holder.mTargetTitle, mTargetLanguage.getId(), mTargetLanguage.getDirection());
             if(!item.isTranslationMergeConflicted) {
-                Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mTargetBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
-                Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mTargetEditableBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+                Typography.format(mContext, Typography.TranslationType.TRANSLATION, holder.mTargetBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+                Typography.format(mContext, Typography.TranslationType.TRANSLATION, holder.mTargetEditableBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
             } else {
-                Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mHeadText, mTargetLanguage.getId(), mTargetLanguage.getDirection());
-                Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mTailText, mTargetLanguage.getId(), mTargetLanguage.getDirection());
-                Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mConflictText, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+                Typography.format(mContext, Typography.TranslationType.TRANSLATION, holder.mHeadText, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+                Typography.format(mContext, Typography.TranslationType.TRANSLATION, holder.mTailText, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+                Typography.format(mContext, Typography.TranslationType.TRANSLATION, holder.mConflictText, mTargetLanguage.getId(), mTargetLanguage.getDirection());
             }
         }
 //        this.onBind = false;
@@ -798,8 +798,8 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
             item.tailText = span;
         }
 
-        Typography.formatSub(mContext, Typography.RENDER_TRANSLATION, holder.mHeadText, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-        Typography.formatSub(mContext, Typography.RENDER_TRANSLATION, holder.mTailText, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+        Typography.formatSub(mContext, Typography.TranslationType.TRANSLATION, holder.mHeadText, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+        Typography.formatSub(mContext, Typography.TranslationType.TRANSLATION, holder.mTailText, mSourceLanguage.getId(), mSourceLanguage.getDirection());
 
         if(mInitialTextSize == 0) { // see if we need to initialize values
             mMarginInitialLeft = leftMargin(holder.mHeadText);
@@ -1736,7 +1736,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                         }
                     }
                 });
-                Typography.formatSub(mContext, Typography.RENDER_SOURCE, noteView, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+                Typography.formatSub(mContext, Typography.TranslationType.SOURCE, noteView, mSourceLanguage.getId(), mSourceLanguage.getDirection());
                 holder.mResourceList.addView(noteView);
             }
         } else if(mOpenResourceTab[position] == TAB_WORDS) {
@@ -1752,7 +1752,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                         }
                     }
                 });
-                Typography.formatSub(mContext, Typography.RENDER_SOURCE, wordView, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+                Typography.formatSub(mContext, Typography.TranslationType.SOURCE, wordView, mSourceLanguage.getId(), mSourceLanguage.getDirection());
                 holder.mResourceList.addView(wordView);
             }
         } else if(mOpenResourceTab[position] == TAB_QUESTIONS) {
@@ -1768,7 +1768,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                         }
                     }
                 });
-                Typography.formatSub(mContext, Typography.RENDER_SOURCE, questionView, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+                Typography.formatSub(mContext, Typography.TranslationType.SOURCE, questionView, mSourceLanguage.getId(), mSourceLanguage.getDirection());
                 holder.mResourceList.addView(questionView);
             }
         }

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeAdapter.java
@@ -427,15 +427,15 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
         // set up fonts
         if(holder.mLayoutBuildNumber != mLayoutBuildNumber) {
             holder.mLayoutBuildNumber = mLayoutBuildNumber;
-            Typography.format(mContext, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-            Typography.formatSub(mContext, holder.mTargetTitle, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+            Typography.format(mContext, Typography.RENDER_SOURCE, holder.mSourceBody, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+            Typography.formatSub(mContext, Typography.RENDER_TRANSLATION, holder.mTargetTitle, mTargetLanguage.getId(), mTargetLanguage.getDirection());
             if(!item.isTranslationMergeConflicted) {
-                Typography.format(mContext, holder.mTargetBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
-                Typography.format(mContext, holder.mTargetEditableBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+                Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mTargetBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+                Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mTargetEditableBody, mTargetLanguage.getId(), mTargetLanguage.getDirection());
             } else {
-                Typography.format(mContext, holder.mHeadText, mTargetLanguage.getId(), mTargetLanguage.getDirection());
-                Typography.format(mContext, holder.mTailText, mTargetLanguage.getId(), mTargetLanguage.getDirection());
-                Typography.format(mContext, holder.mConflictText, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+                Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mHeadText, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+                Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mTailText, mTargetLanguage.getId(), mTargetLanguage.getDirection());
+                Typography.format(mContext, Typography.RENDER_TRANSLATION, holder.mConflictText, mTargetLanguage.getId(), mTargetLanguage.getDirection());
             }
         }
 //        this.onBind = false;
@@ -798,8 +798,8 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
             item.tailText = span;
         }
 
-        Typography.formatSub(mContext, holder.mHeadText, mSourceLanguage.getId(), mSourceLanguage.getDirection());
-        Typography.formatSub(mContext, holder.mTailText, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+        Typography.formatSub(mContext, Typography.RENDER_TRANSLATION, holder.mHeadText, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+        Typography.formatSub(mContext, Typography.RENDER_TRANSLATION, holder.mTailText, mSourceLanguage.getId(), mSourceLanguage.getDirection());
 
         if(mInitialTextSize == 0) { // see if we need to initialize values
             mMarginInitialLeft = leftMargin(holder.mHeadText);
@@ -1736,7 +1736,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                         }
                     }
                 });
-                Typography.formatSub(mContext, noteView, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+                Typography.formatSub(mContext, Typography.RENDER_SOURCE, noteView, mSourceLanguage.getId(), mSourceLanguage.getDirection());
                 holder.mResourceList.addView(noteView);
             }
         } else if(mOpenResourceTab[position] == TAB_WORDS) {
@@ -1752,7 +1752,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                         }
                     }
                 });
-                Typography.formatSub(mContext, wordView, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+                Typography.formatSub(mContext, Typography.RENDER_SOURCE, wordView, mSourceLanguage.getId(), mSourceLanguage.getDirection());
                 holder.mResourceList.addView(wordView);
             }
         } else if(mOpenResourceTab[position] == TAB_QUESTIONS) {
@@ -1768,7 +1768,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                         }
                     }
                 });
-                Typography.formatSub(mContext, questionView, mSourceLanguage.getId(), mSourceLanguage.getDirection());
+                Typography.formatSub(mContext, Typography.RENDER_SOURCE, questionView, mSourceLanguage.getId(), mSourceLanguage.getDirection());
                 holder.mResourceList.addView(questionView);
             }
         }

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeFragment.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeFragment.java
@@ -296,7 +296,7 @@ public class ReviewModeFragment extends ViewModeFragment {
                     startActivity(intent);
                 }
             });
-            view.loadData(Typography.getStyle(getActivity())
+            view.loadData(Typography.getStyle(getActivity(), Typography.RENDER_SOURCE )
                     + renderer.render(article.getBody()).toString(), "text/html", "utf-8");
 
             mScrollingResourcesDrawerContent.removeAllViews();
@@ -365,7 +365,7 @@ public class ReviewModeFragment extends ViewModeFragment {
 
             wordTitle.setText(word.getTerm());
             descriptionTitle.setText(word.getDefinitionTitle());
-            Typography.formatTitle(getActivity(), descriptionTitle, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.formatTitle(getActivity(), Typography.RENDER_SOURCE, descriptionTitle, sourceLanguage.getId(), sourceLanguage.getDirection());
             HtmlRenderer renderer = new HtmlRenderer(new HtmlRenderer.OnPreprocessLink() {
                 @Override
                 public boolean onPreprocess(Span span) {
@@ -409,7 +409,7 @@ public class ReviewModeFragment extends ViewModeFragment {
             });
             descriptionView.setText(renderer.render(word.getDefinition()));
             descriptionView.setMovementMethod(LocalLinkMovementMethod.getInstance());
-            Typography.formatSub(getActivity(), descriptionView, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, descriptionView, sourceLanguage.getId(), sourceLanguage.getDirection());
 
             seeAlsoView.removeAllViews();
             for(int i = 0; i < word.getSeeAlso().length; i ++) {
@@ -423,7 +423,7 @@ public class ReviewModeFragment extends ViewModeFragment {
                             onTranslationWordClick(relatedWord.getId(), mResourcesDrawer.getLayoutParams().width);
                         }
                     });
-                    Typography.formatSub(getActivity(), button, sourceLanguage.getId(), sourceLanguage.getDirection());
+                    Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, button, sourceLanguage.getId(), sourceLanguage.getDirection());
                     seeAlsoView.addView(button);
                 }
             }
@@ -432,7 +432,7 @@ public class ReviewModeFragment extends ViewModeFragment {
             } else {
                 seeAlsoTitle.setVisibility(View.GONE);
             }
-            Typography.formatTitle(getActivity(), seeAlsoTitle, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.formatTitle(getActivity(), Typography.RENDER_SOURCE, seeAlsoTitle, sourceLanguage.getId(), sourceLanguage.getDirection());
 
             examplesView.removeAllViews();
             for(final TranslationWord.Example example:word.getExamples()) {
@@ -448,8 +448,8 @@ public class ReviewModeFragment extends ViewModeFragment {
                         scrollToFrame(example.getChapterId(), example.getFrameId());
                     }
                 });
-                Typography.formatSub(getActivity(), referenceView, sourceLanguage.getId(), sourceLanguage.getDirection());
-                Typography.formatSub(getActivity(), passageView, sourceLanguage.getId(), sourceLanguage.getDirection());
+                Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, referenceView, sourceLanguage.getId(), sourceLanguage.getDirection());
+                Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, passageView, sourceLanguage.getId(), sourceLanguage.getDirection());
                 examplesView.addView(exampleView);
             }
             if(word.getExamples().length > 0) {
@@ -457,7 +457,7 @@ public class ReviewModeFragment extends ViewModeFragment {
             } else {
                 examplesTitle.setVisibility(View.GONE);
             }
-            Typography.formatTitle(getActivity(), examplesTitle, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.formatTitle(getActivity(), Typography.RENDER_SOURCE, examplesTitle, sourceLanguage.getId(), sourceLanguage.getDirection());
 
             mScrollingResourcesDrawerContent.removeAllViews();
             mScrollingResourcesDrawerContent.addView(view);
@@ -541,10 +541,10 @@ public class ReviewModeFragment extends ViewModeFragment {
 
             title.setText(note.getTitle());
             SourceLanguage sourceLanguage = library.getSourceLanguage(sourceTranslation.projectSlug, sourceTranslation.sourceLanguageSlug);
-            Typography.format(getActivity(), title, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.format(getActivity(), Typography.RENDER_SOURCE, title, sourceLanguage.getId(), sourceLanguage.getDirection());
 
             descriptionView.setText(renderer.render(note.getBody()));
-            Typography.formatSub(getActivity(), descriptionView, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, descriptionView, sourceLanguage.getId(), sourceLanguage.getDirection());
             descriptionView.setMovementMethod(LocalLinkMovementMethod.getInstance());
 
             mScrollingResourcesDrawerContent.removeAllViews();
@@ -578,13 +578,13 @@ public class ReviewModeFragment extends ViewModeFragment {
 //            mCloseResourcesDrawerButton.setText(question.getQuestion());
 
             TextView questionTitle = (TextView)view.findViewById(R.id.question_title);
-            Typography.formatTitle(getActivity(), questionTitle, sourceLanguage.getId(), sourceLanguage.direction);
+            Typography.formatTitle(getActivity(), Typography.RENDER_SOURCE, questionTitle, sourceLanguage.getId(), sourceLanguage.direction);
             TextView questionView = (TextView)view.findViewById(R.id.question);
             TextView answerTitle = (TextView)view.findViewById(R.id.answer_title);
-            Typography.formatTitle(getActivity(), answerTitle, sourceLanguage.getId(), sourceLanguage.direction);
+            Typography.formatTitle(getActivity(), Typography.RENDER_SOURCE, answerTitle, sourceLanguage.getId(), sourceLanguage.direction);
             TextView answerView = (TextView)view.findViewById(R.id.answer);
             TextView referencesTitle = (TextView)view.findViewById(R.id.references_title);
-            Typography.formatTitle(getActivity(), referencesTitle, sourceLanguage.getId(), sourceLanguage.direction);
+            Typography.formatTitle(getActivity(), Typography.RENDER_SOURCE, referencesTitle, sourceLanguage.getId(), sourceLanguage.direction);
             LinearLayout referencesLayout = (LinearLayout)view.findViewById(R.id.references);
 
             referencesLayout.removeAllViews();
@@ -592,7 +592,7 @@ public class ReviewModeFragment extends ViewModeFragment {
                 TextView referenceView = (TextView) getActivity().getLayoutInflater().inflate(R.layout.fragment_resources_reference_item, null);
                 Frame frame = library.getFrame(sourceTranslation, reference.getChapterId(), reference.getFrameId());
                 referenceView.setText(sourceTranslation.getProjectTitle() + " " + Integer.parseInt(reference.getChapterId()) + ":" + frame.getTitle());
-                Typography.formatSub(getActivity(), referenceView, sourceLanguage.getId(), sourceLanguage.direction);
+                Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, referenceView, sourceLanguage.getId(), sourceLanguage.direction);
                 referenceView.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
@@ -603,9 +603,9 @@ public class ReviewModeFragment extends ViewModeFragment {
             }
 
             questionView.setText(question.getQuestion());
-            Typography.formatSub(getActivity(), questionView, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, questionView, sourceLanguage.getId(), sourceLanguage.getDirection());
             answerView.setText(question.getAnswer());
-            Typography.formatSub(getActivity(), answerView, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, answerView, sourceLanguage.getId(), sourceLanguage.getDirection());
 
             mScrollingResourcesDrawerContent.removeAllViews();
             mScrollingResourcesDrawerContent.addView(view);

--- a/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeFragment.java
+++ b/app/src/main/java/com/door43/translationstudio/newui/translate/ReviewModeFragment.java
@@ -296,7 +296,7 @@ public class ReviewModeFragment extends ViewModeFragment {
                     startActivity(intent);
                 }
             });
-            view.loadData(Typography.getStyle(getActivity(), Typography.RENDER_SOURCE )
+            view.loadData(Typography.getStyle(getActivity(), Typography.TranslationType.SOURCE )
                     + renderer.render(article.getBody()).toString(), "text/html", "utf-8");
 
             mScrollingResourcesDrawerContent.removeAllViews();
@@ -365,7 +365,7 @@ public class ReviewModeFragment extends ViewModeFragment {
 
             wordTitle.setText(word.getTerm());
             descriptionTitle.setText(word.getDefinitionTitle());
-            Typography.formatTitle(getActivity(), Typography.RENDER_SOURCE, descriptionTitle, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.formatTitle(getActivity(), Typography.TranslationType.SOURCE, descriptionTitle, sourceLanguage.getId(), sourceLanguage.getDirection());
             HtmlRenderer renderer = new HtmlRenderer(new HtmlRenderer.OnPreprocessLink() {
                 @Override
                 public boolean onPreprocess(Span span) {
@@ -409,7 +409,7 @@ public class ReviewModeFragment extends ViewModeFragment {
             });
             descriptionView.setText(renderer.render(word.getDefinition()));
             descriptionView.setMovementMethod(LocalLinkMovementMethod.getInstance());
-            Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, descriptionView, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.formatSub(getActivity(), Typography.TranslationType.SOURCE, descriptionView, sourceLanguage.getId(), sourceLanguage.getDirection());
 
             seeAlsoView.removeAllViews();
             for(int i = 0; i < word.getSeeAlso().length; i ++) {
@@ -423,7 +423,7 @@ public class ReviewModeFragment extends ViewModeFragment {
                             onTranslationWordClick(relatedWord.getId(), mResourcesDrawer.getLayoutParams().width);
                         }
                     });
-                    Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, button, sourceLanguage.getId(), sourceLanguage.getDirection());
+                    Typography.formatSub(getActivity(), Typography.TranslationType.SOURCE, button, sourceLanguage.getId(), sourceLanguage.getDirection());
                     seeAlsoView.addView(button);
                 }
             }
@@ -432,7 +432,7 @@ public class ReviewModeFragment extends ViewModeFragment {
             } else {
                 seeAlsoTitle.setVisibility(View.GONE);
             }
-            Typography.formatTitle(getActivity(), Typography.RENDER_SOURCE, seeAlsoTitle, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.formatTitle(getActivity(), Typography.TranslationType.SOURCE, seeAlsoTitle, sourceLanguage.getId(), sourceLanguage.getDirection());
 
             examplesView.removeAllViews();
             for(final TranslationWord.Example example:word.getExamples()) {
@@ -448,8 +448,8 @@ public class ReviewModeFragment extends ViewModeFragment {
                         scrollToFrame(example.getChapterId(), example.getFrameId());
                     }
                 });
-                Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, referenceView, sourceLanguage.getId(), sourceLanguage.getDirection());
-                Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, passageView, sourceLanguage.getId(), sourceLanguage.getDirection());
+                Typography.formatSub(getActivity(), Typography.TranslationType.SOURCE, referenceView, sourceLanguage.getId(), sourceLanguage.getDirection());
+                Typography.formatSub(getActivity(), Typography.TranslationType.SOURCE, passageView, sourceLanguage.getId(), sourceLanguage.getDirection());
                 examplesView.addView(exampleView);
             }
             if(word.getExamples().length > 0) {
@@ -457,7 +457,7 @@ public class ReviewModeFragment extends ViewModeFragment {
             } else {
                 examplesTitle.setVisibility(View.GONE);
             }
-            Typography.formatTitle(getActivity(), Typography.RENDER_SOURCE, examplesTitle, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.formatTitle(getActivity(), Typography.TranslationType.SOURCE, examplesTitle, sourceLanguage.getId(), sourceLanguage.getDirection());
 
             mScrollingResourcesDrawerContent.removeAllViews();
             mScrollingResourcesDrawerContent.addView(view);
@@ -541,10 +541,10 @@ public class ReviewModeFragment extends ViewModeFragment {
 
             title.setText(note.getTitle());
             SourceLanguage sourceLanguage = library.getSourceLanguage(sourceTranslation.projectSlug, sourceTranslation.sourceLanguageSlug);
-            Typography.format(getActivity(), Typography.RENDER_SOURCE, title, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.format(getActivity(), Typography.TranslationType.SOURCE, title, sourceLanguage.getId(), sourceLanguage.getDirection());
 
             descriptionView.setText(renderer.render(note.getBody()));
-            Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, descriptionView, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.formatSub(getActivity(), Typography.TranslationType.SOURCE, descriptionView, sourceLanguage.getId(), sourceLanguage.getDirection());
             descriptionView.setMovementMethod(LocalLinkMovementMethod.getInstance());
 
             mScrollingResourcesDrawerContent.removeAllViews();
@@ -578,13 +578,13 @@ public class ReviewModeFragment extends ViewModeFragment {
 //            mCloseResourcesDrawerButton.setText(question.getQuestion());
 
             TextView questionTitle = (TextView)view.findViewById(R.id.question_title);
-            Typography.formatTitle(getActivity(), Typography.RENDER_SOURCE, questionTitle, sourceLanguage.getId(), sourceLanguage.direction);
+            Typography.formatTitle(getActivity(), Typography.TranslationType.SOURCE, questionTitle, sourceLanguage.getId(), sourceLanguage.direction);
             TextView questionView = (TextView)view.findViewById(R.id.question);
             TextView answerTitle = (TextView)view.findViewById(R.id.answer_title);
-            Typography.formatTitle(getActivity(), Typography.RENDER_SOURCE, answerTitle, sourceLanguage.getId(), sourceLanguage.direction);
+            Typography.formatTitle(getActivity(), Typography.TranslationType.SOURCE, answerTitle, sourceLanguage.getId(), sourceLanguage.direction);
             TextView answerView = (TextView)view.findViewById(R.id.answer);
             TextView referencesTitle = (TextView)view.findViewById(R.id.references_title);
-            Typography.formatTitle(getActivity(), Typography.RENDER_SOURCE, referencesTitle, sourceLanguage.getId(), sourceLanguage.direction);
+            Typography.formatTitle(getActivity(), Typography.TranslationType.SOURCE, referencesTitle, sourceLanguage.getId(), sourceLanguage.direction);
             LinearLayout referencesLayout = (LinearLayout)view.findViewById(R.id.references);
 
             referencesLayout.removeAllViews();
@@ -592,7 +592,7 @@ public class ReviewModeFragment extends ViewModeFragment {
                 TextView referenceView = (TextView) getActivity().getLayoutInflater().inflate(R.layout.fragment_resources_reference_item, null);
                 Frame frame = library.getFrame(sourceTranslation, reference.getChapterId(), reference.getFrameId());
                 referenceView.setText(sourceTranslation.getProjectTitle() + " " + Integer.parseInt(reference.getChapterId()) + ":" + frame.getTitle());
-                Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, referenceView, sourceLanguage.getId(), sourceLanguage.direction);
+                Typography.formatSub(getActivity(), Typography.TranslationType.SOURCE, referenceView, sourceLanguage.getId(), sourceLanguage.direction);
                 referenceView.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
@@ -603,9 +603,9 @@ public class ReviewModeFragment extends ViewModeFragment {
             }
 
             questionView.setText(question.getQuestion());
-            Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, questionView, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.formatSub(getActivity(), Typography.TranslationType.SOURCE, questionView, sourceLanguage.getId(), sourceLanguage.getDirection());
             answerView.setText(question.getAnswer());
-            Typography.formatSub(getActivity(), Typography.RENDER_SOURCE, answerView, sourceLanguage.getId(), sourceLanguage.getDirection());
+            Typography.formatSub(getActivity(), Typography.TranslationType.SOURCE, answerView, sourceLanguage.getId(), sourceLanguage.getDirection());
 
             mScrollingResourcesDrawerContent.removeAllViews();
             mScrollingResourcesDrawerContent.addView(view);

--- a/app/src/main/java/com/door43/translationstudio/tasks/PrintPDFTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/PrintPDFTask.java
@@ -40,7 +40,7 @@ public class PrintPDFTask extends ManagedTask {
             try {
                 SourceTranslation sourceTranslation = App.getLibrary().getDefaultSourceTranslation(mTargetTranslation.getProjectId(), "en");
                 File imagesDir = library.getImagesDir();
-                translator.exportPdf(library, mTargetTranslation, sourceTranslation.getFormat(), Typography.getAssetPath(App.context(), Typography.RENDER_TRANSLATION), imagesDir, includeImages, includeIncompleteFrames, mDestFile);
+                translator.exportPdf(library, mTargetTranslation, sourceTranslation.getFormat(), Typography.getAssetPath(App.context(), Typography.TranslationType.TRANSLATION), imagesDir, includeImages, includeIncompleteFrames, mDestFile);
                 if (mDestFile.exists()) {
                     success = true;
                 } else {

--- a/app/src/main/java/com/door43/translationstudio/tasks/PrintPDFTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/PrintPDFTask.java
@@ -40,7 +40,7 @@ public class PrintPDFTask extends ManagedTask {
             try {
                 SourceTranslation sourceTranslation = App.getLibrary().getDefaultSourceTranslation(mTargetTranslation.getProjectId(), "en");
                 File imagesDir = library.getImagesDir();
-                translator.exportPdf(library, mTargetTranslation, sourceTranslation.getFormat(), Typography.getAssetPath(App.context()), imagesDir, includeImages, includeIncompleteFrames, mDestFile);
+                translator.exportPdf(library, mTargetTranslation, sourceTranslation.getFormat(), Typography.getAssetPath(App.context(), Typography.RENDER_TRANSLATION), imagesDir, includeImages, includeIncompleteFrames, mDestFile);
                 if (mDestFile.exists()) {
                     success = true;
                 } else {

--- a/app/src/main/res/values/strings_user_pref.xml
+++ b/app/src/main/res/values/strings_user_pref.xml
@@ -18,18 +18,21 @@
     <string name="pref_description_always_share">Allow nearby translators to import my translations while the app is open</string>
 
     <!-- Title for the typefaced used in the app -->
-    <string name="pref_title_translation_typeface">Font</string>
+    <string name="pref_title_translation_typeface">Translation Font</string>
     <string-array name="pref_translation_typeface_titles" translatable="false">
         <item>Gentium Plus</item>
     </string-array>
     <!-- The font size of the translation typeface -->
-    <string name="pref_title_typeface_size">Font Size</string>
+    <string name="pref_title_typeface_size">Translation Font Size</string>
     <string-array name="pref_typeface_size_titles">
         <item>small</item>
         <item>normal</item>
         <item>medium</item>
         <item>large</item>
     </string-array>
+
+    <string name="pref_title_source_typeface">Source Font</string>
+    <string name="pref_title_source_typeface_size">Source Font Size</string>
 
     <!-- Section heading for the Upload settings -->
     <string name="pref_header_synchronization">Server</string>

--- a/app/src/main/res/xml/general_preferences.xml
+++ b/app/src/main/res/xml/general_preferences.xml
@@ -23,6 +23,24 @@
         android:negativeButtonText="@null"
         android:positiveButtonText="@null" />
 
+    <ListPreference
+        android:key="source_typeface"
+        android:title="@string/pref_title_source_typeface"
+        android:entries="@array/pref_translation_typeface_titles"
+        android:entryValues="@array/pref_translation_typeface_values"
+        android:defaultValue="@string/pref_default_translation_typeface"
+        android:negativeButtonText="@null"
+        android:positiveButtonText="@null" />
+
+    <ListPreference
+        android:key="source_typeface_size"
+        android:title="@string/pref_title_source_typeface_size"
+        android:entries="@array/pref_typeface_size_titles"
+        android:entryValues="@array/pref_typeface_size_values"
+        android:defaultValue="@string/pref_default_typeface_size"
+        android:negativeButtonText="@null"
+        android:positiveButtonText="@null" />
+
     <CheckBoxPreference
         android:key="always_share"
         android:title="@string/pref_title_always_share"


### PR DESCRIPTION
Fix #1549 provide font settings for source translation and target translation.

Changes in this pull request:
- Expanded Preferences to include both source and translation font settings. 
- Changed Typography to include a selector for either source or target.