### PR TITLE
Fix #1588 fix done toggle

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -751,6 +751,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
         }
         if (opened) {
             item.renderedTargetText = null;
+            item.isComplete = false;
             notifyDataSetChanged();
         } else {
             // TODO: 10/27/2015 notify user the frame could not be completed.
@@ -1375,6 +1376,8 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                 Snackbar snack = Snackbar.make(mContext.findViewById(android.R.id.content), R.string.failed_to_commit_chunk, Snackbar.LENGTH_LONG);
                 ViewUtil.setSnackBarTextColor(snack, mContext.getResources().getColor(R.color.light_primary_text));
                 snack.show();
+            } else {
+                item.isComplete = true;
             }
         }
 


### PR DESCRIPTION
Fix #1588 fix done toggle

Changes in this pull request:
- 	ReviewModeAdapter - fix for setting item.isComplete state on done toggle.


@neutrinog - it looks like the problem was with a new isComplete flag that was getting changed with toggle button - so card was getting redrawn back to initial state.