### PR TITLE
Fixes to ChooseSourceTranslationAdapter checking has updates.  holder…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
         applicationId "com.translationstudio.androidapp"
         minSdkVersion 15
         targetSdkVersion 23
-        versionCode 148
+        versionCode 149
         versionName "11.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationAdapter.java
@@ -231,10 +231,11 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
 
         // load update status
         final ViewHolder staticHolder = holder;
+        staticHolder.currentPosition = position;
         ManagedTask oldTask = TaskManager.getTask(holder.currentTaskId);
         TaskManager.cancelTask(oldTask);
         TaskManager.clearTask(oldTask);
-        if(!item.checkedUpdates && !item.downloaded) {
+        if(!item.checkedUpdates && item.downloaded) {
             ManagedTask task = new ManagedTask() {
                 @Override
                 public void start() {
@@ -250,22 +251,25 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
             };
             task.addOnFinishedListener(new ManagedTask.OnFinishedListener() {
                 @Override
-                public void onTaskFinished(ManagedTask task) {
+                public void onTaskFinished(final ManagedTask task) {
                     TaskManager.clearTask(task);
                     boolean hasUpdates = false;
                     if(task.getResult() != null) hasUpdates = (boolean)task.getResult();
                     item.hasUpdates = hasUpdates;
-                    if(!task.isCanceled() && position == staticHolder.currentPosition) {
+                    item.checkedUpdates = true;
                         Handler hand = new Handler(Looper.getMainLooper());
                         hand.post(new Runnable() {
                             @Override
                             public void run() {
-                                notifyDataSetChanged();
+                                if(!task.isCanceled() && position == staticHolder.currentPosition) {
+                                    notifyDataSetChanged();
+                                }
                             }
                         });
-                    }
+
                 }
             });
+            holder.currentTaskId = TaskManager.addTask(task);
         }
 
         holder.titleView.setText(item.title);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -916,4 +916,5 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
     <string name="update_warning">Checking for new and updated source texts will close this project. This requires an Internet Connection.</string>
     <string name="view_updated_source">View New and Updated Source Texts</string>
     <string name="check_app_update">Check for Update to translationStudio</string>
+    <string name="all_up_to_date">All Source Texts already up to date!</string>
 </resources>


### PR DESCRIPTION
Fix #1693 implement view new and updated sources workflow - fix that updated sources did not have refresh button.

Changes in this pull request:
- Fixes to ChooseSourceTranslationAdapter checking has updates. holder position is now saved. Fixed logic error for checking if downloaded. Now sets the checkedUpdates flag. Fix a race condition for checking cancelled or position changed. Fix that ManagedTask wasn't being added to TaskManager.