### PR TITLE
Fix #1547 Wrong error message when trying to log into Door43.

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/LoginDoor43Activity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/LoginDoor43Activity.java
@@ -82,14 +82,17 @@ public class LoginDoor43Activity extends AppCompatActivity implements ManagedTas
             App.setProfile(profile);
             finish();
         } else {
+            final boolean networkAvailable = App.isNetworkAvailable();
+
             // login failed
             Handler hand = new Handler(Looper.getMainLooper());
             hand.post(new Runnable() {
                 @Override
                 public void run() {
+                    int messageId = networkAvailable ? R.string.double_check_credentials : R.string.internet_not_available;
                     new AlertDialog.Builder(LoginDoor43Activity.this, R.style.AppTheme_Dialog)
                             .setTitle(R.string.error)
-                            .setMessage(R.string.double_check_credentials)
+                            .setMessage(messageId)
                             .setPositiveButton(R.string.label_ok, null)
                             .show();
                 }


### PR DESCRIPTION
Fix #1547 Wrong error message when trying to log into Door43.

Changes in this pull request:
- Added check for network connectivity before showing login error.

@neutrinog - for review