### PR TITLE
Fix #1527 Enhance error dialog when upload fails

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
@@ -161,9 +161,7 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
 
                     doPullTargetTranslationTask(targetTranslation, MergeStrategy.RECURSIVE);
                 } else {
-                    Snackbar snack = Snackbar.make(getActivity().findViewById(android.R.id.content), R.string.internet_not_available, Snackbar.LENGTH_LONG);
-                    ViewUtil.setSnackBarTextColor(snack, getResources().getColor(R.color.light_primary_text));
-                    snack.show();
+                    showNoInternetDialog(); // replaced snack popup which could be hidden behind dialog
                 }
             }
         });
@@ -771,7 +769,7 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
      * @param targetTranslation
      */
     private void notifyBackupFailed(final TargetTranslation targetTranslation) {
-        if (App.isNetworkAvailable()) {
+        if (!App.isNetworkAvailable()) {
             showNoInternetDialog();
         } else {
             showUploadFailedDialog(targetTranslation);

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
@@ -263,7 +263,11 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
                         break;
 
                     case BACKUP_FAILED:
-                        notifyBackupFailed(targetTranslation);
+                        showUploadFailedDialog(targetTranslation);
+                        break;
+
+                    case NO_INTERNET:
+                        showNoInternetDialog();
                         break;
 
                     case ACCESS_REQUEST:
@@ -767,9 +771,38 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
      * @param targetTranslation
      */
     private void notifyBackupFailed(final TargetTranslation targetTranslation) {
+        if (App.isNetworkAvailable()) {
+            showNoInternetDialog();
+        } else {
+            showUploadFailedDialog(targetTranslation);
+        }
+    }
+
+    /**
+     * show internet not available dialog
+     */
+    private void showNoInternetDialog() {
+        mDialogShown = eDialogShown.NO_INTERNET;
+        new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
+                .setTitle(R.string.upload_failed)
+                .setMessage(R.string.internet_not_available)
+                .setPositiveButton(R.string.label_ok, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        mDialogShown = eDialogShown.NONE;
+                    }
+                })
+                .show();
+    }
+
+    /**
+     * show general upload failed dialog
+     * @param targetTranslation
+     */
+    private void showUploadFailedDialog(final TargetTranslation targetTranslation) {
         mDialogShown = eDialogShown.BACKUP_FAILED;
         new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
-        .setTitle(R.string.backup)
+                .setTitle(R.string.backup)
                 .setMessage(R.string.upload_failed)
                 .setPositiveButton(R.string.dismiss, new DialogInterface.OnClickListener() {
                     @Override
@@ -904,7 +937,8 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
         SHOW_PUSH_SUCCESS(6),
         MERGE_CONFLICT(7),
         EXPORT_TO_USFM_PROMPT(8),
-        EXPORT_TO_USFM_RESULTS(9);
+        EXPORT_TO_USFM_RESULTS(9),
+        NO_INTERNET(10);
 
         private int value;
 


### PR DESCRIPTION
Fix #1527 Enhance error dialog when upload fails

Changes in this pull request:
- BackupDialog: Added alert dialog if upload failed and we have lost internet connection.
- BackupDialog: backup to cloud button now shows no internet connection dialog instead of snack.  Snack would be hidden behind dialog on smaller screens.

@neutrinog

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1748)
<!-- Reviewable:end -->
