### PR TITLE
Fix #1424 Long Language names overflow the language column on the projects screens

### DIFF
--- a/app/src/main/res/layout/fragment_target_translation_list_item.xml
+++ b/app/src/main/res/layout/fragment_target_translation_list_item.xml
@@ -30,7 +30,7 @@
             android:textColor="@color/dark_primary_text" />
     </LinearLayout>
 
-    <LinearLayout
+    <RelativeLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
@@ -42,7 +42,10 @@
             android:layout_height="wrap_content"
             android:layout_marginLeft="16dp"
             android:textColor="@color/dark_secondary_text"
-            android:text="this is some text" />
+            android:text="this is some text"
+            android:layout_alignParentLeft="true"
+            android:layout_centerVertical="true"
+            android:layout_toLeftOf="@+id/instruments" />
 
         <LinearLayout
             android:orientation="horizontal"
@@ -51,7 +54,10 @@
             android:layout_marginLeft="16dp"
             android:layout_weight="1"
             android:animateLayoutChanges="true"
-            android:gravity="right|center_vertical">
+            android:gravity="right|center_vertical"
+            android:layout_alignParentRight="true"
+            android:layout_centerVertical="true"
+            android:id="@+id/instruments">
 
             <com.filippudak.ProgressPieView.ProgressPieView
                 android:layout_margin="@dimen/fab_margin"
@@ -70,7 +76,7 @@
                 android:layout_height="wrap_content"
                 android:background="@drawable/ic_info_black_36dp"/>
         </LinearLayout>
-    </LinearLayout>
+    </RelativeLayout>
 
 
 </LinearLayout>


### PR DESCRIPTION
Fix #1424 Long Language names overflow the language column on the projects screens

Changes in this pull request:
- 	fragment_target_translation_list_item - Changed language side to use RelativeLayout to prevent overlapping language name on progress and info icons.

@neutrinog

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1749)
<!-- Reviewable:end -->
