### PR TITLE
Fix #1246 fix image download

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     compile 'com.facebook.rebound:rebound:0.3.8'
 
     compile 'org.unfoldingword.tools:gogs-client:1.6.1'
-    compile 'org.unfoldingword.tools:task-manager:1.5.0'
+    compile 'org.unfoldingword.tools:task-manager:1.5.1'
     compile 'org.unfoldingword.tools:door43-client:0.9.6'
     compile 'org.unfoldingword.tools:http:2.4.1'
     compile 'org.unfoldingword.tools:logger:2.0.0'

--- a/app/src/androidTest/java/com/door43/translationstudio/core/ExportUsfmTest.java
+++ b/app/src/androidTest/java/com/door43/translationstudio/core/ExportUsfmTest.java
@@ -1,6 +1,7 @@
 package com.door43.translationstudio.core;
 
 import android.content.Context;
+import android.net.Uri;
 import android.test.InstrumentationTestCase;
 import android.util.Log;
 
@@ -78,7 +79,7 @@ public class ExportUsfmTest extends InstrumentationTestCase {
         importTestTranslation(source);
 
         //when
-        File usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, mOutputFolder, null);
+        Uri usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, Uri.fromFile(mOutputFolder), null, false);
 
         //then
         verifyExportedUsfmFile(zipFileName, separateChapters, source, usfmOutput);
@@ -92,7 +93,7 @@ public class ExportUsfmTest extends InstrumentationTestCase {
         importTestTranslation(source);
 
         //when
-        File usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, mOutputFolder, null);
+        Uri usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, Uri.fromFile(mOutputFolder), null, false);
 
         //then
         verifyExportedUsfmFile(zipFileName, separateChapters, source, usfmOutput);
@@ -106,7 +107,7 @@ public class ExportUsfmTest extends InstrumentationTestCase {
         importTestTranslation(source);
 
         //when
-        File usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, mOutputFolder, null);
+        Uri usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, Uri.fromFile(mOutputFolder), null, false);
 
         //then
         verifyExportedUsfmFile(zipFileName, separateChapters, source, usfmOutput);
@@ -120,7 +121,7 @@ public class ExportUsfmTest extends InstrumentationTestCase {
         importTestTranslation(source);
 
         //when
-        File usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, mOutputFolder, null);
+        Uri usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, Uri.fromFile(mOutputFolder), null, false);
 
         //then
         verifyExportedUsfmFile(zipFileName, separateChapters, source, usfmOutput);
@@ -134,7 +135,7 @@ public class ExportUsfmTest extends InstrumentationTestCase {
 //        importTestTranslation(source);
 //
 //        //when
-//        File usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, mOutputFolder, zipFileName, separateChapters);
+//        Uri usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, Uri.fromFile(mOutputFolder), null, false);
 //
 //        //then
 //        verifyExportedUsfmFile(zipFileName, separateChapters, source, usfmOutput);
@@ -148,7 +149,7 @@ public class ExportUsfmTest extends InstrumentationTestCase {
 //        importTestTranslation(source);
 //
 //        //when
-//        File usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, mOutputFolder, zipFileName, separateChapters);
+//        Uri usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, Uri.fromFile(mOutputFolder), null, false);
 //
 //        //then
 //        verifyExportedUsfmFile(zipFileName, separateChapters, source, usfmOutput);
@@ -162,7 +163,7 @@ public class ExportUsfmTest extends InstrumentationTestCase {
 //        importTestTranslation(source);
 //
 //        //when
-//        File usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, mOutputFolder, zipFileName, separateChapters);
+//        Uri usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, Uri.fromFile(mOutputFolder), null, false);
 //
 //        //then
 //        verifyExportedUsfmFile(zipFileName, separateChapters, source, usfmOutput);
@@ -176,7 +177,7 @@ public class ExportUsfmTest extends InstrumentationTestCase {
 //        importTestTranslation(source);
 //
 //        //when
-//        File usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, mOutputFolder, zipFileName, separateChapters);
+//        Uri usfmOutput = ExportUsfm.saveToUSFM(mTargetTranslation, Uri.fromFile(mOutputFolder), null, false);
 //
 //        //then
 //        verifyExportedUsfmFile(zipFileName, separateChapters, source, usfmOutput);
@@ -282,22 +283,24 @@ public class ExportUsfmTest extends InstrumentationTestCase {
      * @param usfmOutput - actual output file
      * @throws IOException
      */
-    private void verifyExportedUsfmFile(String zipFileName, boolean separateChapters, String source, File usfmOutput) throws IOException {
+    private void verifyExportedUsfmFile(String zipFileName, boolean separateChapters, String source, Uri usfmOutput) throws IOException {
         assertNotNull("exported file", usfmOutput);
         mErrorLog = "";
         List<Map> sourceToc = getResourceTOC(mTargetTranslation, mLibrary);
         String projectSlug = mTargetTranslation.getProjectId();
         verifyChunking(sourceToc, projectSlug);
+        String usfmOutputPath = usfmOutput.getPath();
+        File usfmOutputFile = new File(usfmOutputPath);
 
         if (zipFileName == null) {
             if (!separateChapters) {
-                verifySingleUsfmFile(source, usfmOutput);
+                verifySingleUsfmFile(source, usfmOutputFile);
             } else {
                 fail("separate chapters without zip is not supported");
             }
         } else {
             if (separateChapters) {
-                verifyUsfmZipFile(source, usfmOutput);
+                verifyUsfmZipFile(source, usfmOutputFile);
             } else {
                 fail("single book with zip is not supported");
             }

--- a/app/src/main/java/com/door43/translationstudio/core/DownloadImages.java
+++ b/app/src/main/java/com/door43/translationstudio/core/DownloadImages.java
@@ -126,7 +126,7 @@ public class DownloadImages {
             return false;
         }
 
-        boolean success = requestToFile(url, fullPath, IMAGES_CATALOG_SIZE, listener);
+        boolean success = requestToFile(url, fullPath, (int) (IMAGES_CATALOG_SIZE * 1.05f), listener);
         if (success) {
             try {
                 File tempDir = new File(mImagesDir, "temp");

--- a/app/src/main/java/com/door43/translationstudio/core/DownloadImages.java
+++ b/app/src/main/java/com/door43/translationstudio/core/DownloadImages.java
@@ -1,0 +1,171 @@
+package com.door43.translationstudio.core;
+
+import com.door43.translationstudio.App;
+import com.door43.translationstudio.R;
+import com.door43.util.FileUtilities;
+import com.door43.util.Zip;
+
+
+import org.unfoldingword.tools.logger.Logger;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+
+/**
+ * Created by blm on 12/28/16.  Revived from pre-resource container code.
+ */
+
+public class DownloadImages {
+    public static final String TAG = DownloadImages.class.getName();
+    private static final String IMAGES_URL = "https://cdn.unfoldingword.org/obs/jpg/obs-images-360px.zip";
+    public static final int IMAGES_CATALOG_SIZE = 37620940;
+
+    /**
+     * Downloads content from a url and returns it as a string
+     * @param apiUrl the url from which the content will be downloaded
+     * @return
+     */
+    private String request(String apiUrl) {
+        HttpURLConnection urlConnection = null;
+        try {
+            URL url = new URL(apiUrl);
+            urlConnection = (HttpURLConnection) url.openConnection();
+            urlConnection.setReadTimeout(5000);
+            urlConnection.setReadTimeout(5000);
+            InputStream in = new BufferedInputStream(urlConnection.getInputStream());
+            String response = FileUtilities.readStreamToString(in);
+            urlConnection.disconnect();
+            return response;
+        } catch (IOException e) {
+            Logger.e(TAG, "Failed to download file " + apiUrl, e);
+            return null;
+        } finally {
+            if(urlConnection != null) {
+                urlConnection.disconnect();
+            }
+        }
+    }
+
+    private boolean requestToFile(String apiUrl, File outputFile, long expectedSize, OnProgressListener listener) {
+        if(apiUrl.trim().isEmpty()) {
+            return false;
+        }
+        URL url;
+        try {
+            url = new URL(apiUrl);
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            return false;
+        }
+
+        try {
+            URLConnection conn = url.openConnection();
+            conn.setReadTimeout(5000);
+            conn.setConnectTimeout(5000);
+
+            FileOutputStream fos = new FileOutputStream(outputFile);
+
+            int updateInterval = 1048 * 50; // send an update each time some bytes have been downloaded
+            int updateQueue = 0;
+            int bytesRead = 0;
+
+            InputStream is = new BufferedInputStream(conn.getInputStream());
+            byte[] buffer = new byte[4096];
+            int n = 0;
+            while((n = is.read(buffer)) != -1) {
+                bytesRead += n;
+                updateQueue += n;
+                fos.write(buffer, 0, n);
+
+                // send updates
+                if(updateQueue >= updateInterval) {
+                    updateQueue = 0;
+                    listener.onProgress(bytesRead, (int) expectedSize);
+                }
+            }
+
+            listener.onProgress(bytesRead, (int) expectedSize);
+
+            return true;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    /**
+     *
+     * @param listener
+     * @return
+     */
+    public boolean download(OnProgressListener listener) {
+        // TODO: 1/21/2016 we need to be sure to download images for the correct project. right now only obs has images
+        // eventually the api will be updated so we can easily download the correct images.
+
+        String url = IMAGES_URL;
+        String filename = url.replaceAll(".*/", "");
+        File basePath = App.publicDir();
+        File imagesDir = new File(basePath, "assets/images");
+        File fullPath = new File(String.format("%s/%s", imagesDir, filename));
+        if (imagesDir == null) {
+            return false;
+        }
+
+        if(!imagesDir.isDirectory()) { // make sure folder exists
+            imagesDir.mkdirs();
+        }
+
+        if (!imagesDir.isDirectory()) {
+            return false;
+        }
+
+        boolean success = requestToFile(url, fullPath, IMAGES_CATALOG_SIZE, listener);
+        if (success) {
+            try {
+                File tempDir = new File(imagesDir, "temp");
+                tempDir.mkdirs();
+                Zip.unzip(fullPath, tempDir);
+                success = true;
+                fullPath.delete();
+                // move files out of dir
+                File[] extractedFiles = tempDir.listFiles();
+                if(extractedFiles != null) {
+                    for (File dir:extractedFiles) {
+                        if(dir.isDirectory()) {
+                            for(File f:dir.listFiles()) {
+                                FileUtilities.moveOrCopyQuietly(f, new File(imagesDir, f.getName()));
+                            }
+                        }
+                    }
+                }
+                FileUtilities.deleteQuietly(tempDir);
+            } catch (IOException e) {
+                success = false;
+            }
+        }
+        return success;
+    }
+
+    public interface OnProgressListener {
+        /**
+         * Progress the progress on an operation between 0 and max
+         * @param progress
+         * @param max
+         * @return the process should stop if returns false
+         */
+        boolean onProgress(int progress, int max);
+
+        /**
+         * Identifes the current task as not quantifiable
+         * @return the process should stop if returns false
+         */
+        boolean onIndeterminate();
+    }
+}

--- a/app/src/main/java/com/door43/translationstudio/core/DownloadImages.java
+++ b/app/src/main/java/com/door43/translationstudio/core/DownloadImages.java
@@ -1,7 +1,6 @@
 package com.door43.translationstudio.core;
 
 import com.door43.translationstudio.App;
-import com.door43.translationstudio.R;
 import com.door43.util.FileUtilities;
 import com.door43.util.Zip;
 
@@ -26,6 +25,7 @@ public class DownloadImages {
     public static final String TAG = DownloadImages.class.getName();
     private static final String IMAGES_URL = "https://cdn.unfoldingword.org/obs/jpg/obs-images-360px.zip";
     public static final int IMAGES_CATALOG_SIZE = 37620940;
+    private File mImagesDir;
 
     /**
      * Downloads content from a url and returns it as a string
@@ -112,24 +112,24 @@ public class DownloadImages {
         String url = IMAGES_URL;
         String filename = url.replaceAll(".*/", "");
         File basePath = App.publicDir();
-        File imagesDir = new File(basePath, "assets/images");
-        File fullPath = new File(String.format("%s/%s", imagesDir, filename));
-        if (imagesDir == null) {
+        mImagesDir = new File(basePath, "assets/images");
+        File fullPath = new File(String.format("%s/%s", mImagesDir, filename));
+        if (mImagesDir == null) {
             return false;
         }
 
-        if(!imagesDir.isDirectory()) { // make sure folder exists
-            imagesDir.mkdirs();
+        if(!mImagesDir.isDirectory()) { // make sure folder exists
+            mImagesDir.mkdirs();
         }
 
-        if (!imagesDir.isDirectory()) {
+        if (!mImagesDir.isDirectory()) {
             return false;
         }
 
         boolean success = requestToFile(url, fullPath, IMAGES_CATALOG_SIZE, listener);
         if (success) {
             try {
-                File tempDir = new File(imagesDir, "temp");
+                File tempDir = new File(mImagesDir, "temp");
                 tempDir.mkdirs();
                 Zip.unzip(fullPath, tempDir);
                 success = true;
@@ -140,7 +140,7 @@ public class DownloadImages {
                     for (File dir:extractedFiles) {
                         if(dir.isDirectory()) {
                             for(File f:dir.listFiles()) {
-                                FileUtilities.moveOrCopyQuietly(f, new File(imagesDir, f.getName()));
+                                FileUtilities.moveOrCopyQuietly(f, new File(mImagesDir, f.getName()));
                             }
                         }
                     }
@@ -167,5 +167,9 @@ public class DownloadImages {
          * @return the process should stop if returns false
          */
         boolean onIndeterminate();
+    }
+
+    public File getImagesDir() {
+        return mImagesDir;
     }
 }

--- a/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
+++ b/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
@@ -265,7 +265,7 @@ public class PdfPrinter extends PdfPageEventHelper {
             ArrayList<FrameTranslation> frameList = ExportUsfm.sortFrameTranslations(frames);
             for(FrameTranslation f: frameList) {
                 if(includeIncomplete || f.isFinished()) {
-                    if(includeMedia && this.format == TranslationFormat.DEFAULT) {
+                    if(includeMedia && this.format == TranslationFormat.MARKDOWN) {
                         // TODO: 11/13/2015 insert frame images if we have them.
                         // TODO: 11/13/2015 eventually we need to provide the directory where to find these images which will be downloaded not in assets
                         try {

--- a/app/src/main/java/com/door43/translationstudio/core/Translator.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Translator.java
@@ -484,8 +484,11 @@ public class Translator {
         printer.includeIncomplete(includeIncompleteFrames);
         File pdf = printer.print();
         if(pdf.exists()) {
-            outputFile.delete();
-            FileUtilities.moveOrCopyQuietly(pdf, outputFile);
+            boolean success = outputFile.delete();
+            success = FileUtilities.moveOrCopyQuietly(pdf, outputFile);
+            if(!outputFile.exists()) {
+                Logger.e(TAG, "Could not move '" + pdf.toString() + "' to '" + outputFile.toString() + "'");
+            }
         }
 
 //        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {

--- a/app/src/main/java/com/door43/translationstudio/tasks/DownloadImagesTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/DownloadImagesTask.java
@@ -7,6 +7,8 @@ import com.door43.translationstudio.core.DownloadImages;
 import org.unfoldingword.tools.logger.Logger;
 import org.unfoldingword.tools.taskmanager.ManagedTask;
 
+import java.io.File;
+
 /**
  * Created by jshuma on 1/11/16.
  */
@@ -16,9 +18,11 @@ public class DownloadImagesTask extends ManagedTask {
 
     private int mMaxProgress = 100;
     private boolean mSuccess;
+    private File mImagesDir;
 
     public DownloadImagesTask() {
         mSuccess = false;
+        mImagesDir = null;
     }
 
     @Override
@@ -46,6 +50,7 @@ public class DownloadImagesTask extends ManagedTask {
                     return !isCanceled();
                 }
             });
+            mImagesDir = downloadImages.getImagesDir();
         } catch (Exception e) {
             Logger.e(this.getClass().getSimpleName(),"Download Failed", e);
         }
@@ -64,5 +69,9 @@ public class DownloadImagesTask extends ManagedTask {
      */
     public boolean getSuccess() {
         return mSuccess;
+    }
+
+    public File getImagesDir() {
+        return mImagesDir;
     }
 }

--- a/app/src/main/java/com/door43/translationstudio/tasks/DownloadImagesTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/DownloadImagesTask.java
@@ -2,8 +2,9 @@ package com.door43.translationstudio.tasks;
 
 import com.door43.translationstudio.App;
 import com.door43.translationstudio.R;
+import com.door43.translationstudio.core.DownloadImages;
 
-import org.unfoldingword.door43client.Door43Client;
+import org.unfoldingword.tools.logger.Logger;
 import org.unfoldingword.tools.taskmanager.ManagedTask;
 
 /**
@@ -13,36 +14,41 @@ public class DownloadImagesTask extends ManagedTask {
 
     public static final String TASK_ID = "download_images_task";
 
-    private final Door43Client mLibrary;
     private int mMaxProgress = 100;
     private boolean mSuccess;
 
     public DownloadImagesTask() {
-        mLibrary = App.getLibrary();
+        mSuccess = false;
     }
 
     @Override
     public void start() {
-//        mSuccess = mLibrary.downloadImages(new Library.OnProgressListener() {
-//
-//            @Override
-//            public boolean onProgress(int progress, int max) {
-//                mMaxProgress = max;
-//                String message = String.format("%2.2f %s %2.2f %s",
-//                        progress / (1024f * 1024f),
-//                        App.context().getResources().getString(R.string.out_of),
-//                        max / (1024f * 1024f),
-//                        App.context().getResources().getString(R.string.mb_downloaded));
-//                publishProgress((float)progress / (float)max, message);
-//                return !isCanceled();
-//            }
-//
-//            @Override
-//            public boolean onIndeterminate() {
-//                publishProgress(-1, "");
-//                return !isCanceled();
-//            }
-//        });
+        mSuccess = false;
+        try {
+            DownloadImages downloadImages = new DownloadImages();
+            mSuccess = downloadImages.download(new DownloadImages.OnProgressListener() {
+
+                @Override
+                public boolean onProgress(int progress, int max) {
+                    mMaxProgress = max;
+                    String message = String.format("%2.2f %s %2.2f %s",
+                            progress / (1024f * 1024f),
+                            App.context().getResources().getString(R.string.out_of),
+                            max / (1024f * 1024f),
+                            App.context().getResources().getString(R.string.mb_downloaded));
+                    publishProgress((float) progress / (float) max, message);
+                    return !isCanceled();
+                }
+
+                @Override
+                public boolean onIndeterminate() {
+                    publishProgress(-1, "");
+                    return !isCanceled();
+                }
+            });
+        } catch (Exception e) {
+            Logger.e(this.getClass().getSimpleName(),"Download Failed", e);
+        }
 
         publishProgress(-1, "");
     }

--- a/app/src/main/java/com/door43/translationstudio/tasks/PrintPDFTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/PrintPDFTask.java
@@ -47,7 +47,6 @@ public class PrintPDFTask extends ManagedTask {
             try {
                 Project p = App.getLibrary().index().getProject("en", mTargetTranslation.getProjectId(), true);
                 List<Resource> resources = App.getLibrary().index().getResources(p.languageSlug, p.slug);
-                ResourceContainer resourceContainer = App.getLibrary().open(p.languageSlug, p.slug, resources.get(0).slug);
                 translator.exportPdf(library, mTargetTranslation, mTargetTranslation.getFormat(), Typography.getAssetPath(App.context(), TranslationType.TARGET), imagesDir, includeImages, includeIncompleteFrames, mDestFile);
                 if (mDestFile.exists()) {
                     success = true;

--- a/app/src/main/java/com/door43/translationstudio/tasks/PrintPDFTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/PrintPDFTask.java
@@ -27,12 +27,14 @@ public class PrintPDFTask extends ManagedTask {
     private final File mDestFile;
     private final boolean includeImages;
     private final boolean includeIncompleteFrames;
+    private final File imagesDir;
     private boolean success;
 
-    public PrintPDFTask(String targetTranslationId, File destFile, boolean includeImages, boolean includeIncompleteFrames) {
+    public PrintPDFTask(String targetTranslationId, File destFile, boolean includeImages, boolean includeIncompleteFrames, File imagesDir) {
         mDestFile = destFile;
         this.includeImages = includeImages;
         this.includeIncompleteFrames = includeIncompleteFrames;
+        this.imagesDir = imagesDir;
         mTargetTranslation = App.getTranslator().getTargetTranslation(targetTranslationId);
     }
 
@@ -46,7 +48,6 @@ public class PrintPDFTask extends ManagedTask {
                 Project p = App.getLibrary().index().getProject("en", mTargetTranslation.getProjectId(), true);
                 List<Resource> resources = App.getLibrary().index().getResources(p.languageSlug, p.slug);
                 ResourceContainer resourceContainer = App.getLibrary().open(p.languageSlug, p.slug, resources.get(0).slug);
-                File imagesDir = App.getImagesDir();
                 translator.exportPdf(library, mTargetTranslation, mTargetTranslation.getFormat(), Typography.getAssetPath(App.context(), TranslationType.TARGET), imagesDir, includeImages, includeIncompleteFrames, mDestFile);
                 if (mDestFile.exists()) {
                     success = true;

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/PrintDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/PrintDialog.java
@@ -79,7 +79,7 @@ public class PrintDialog extends DialogFragment implements SimpleTaskWatcher.OnF
     private String mDestinationFilename;
     private DialogShown mAlertShown = DialogShown.NONE;
     private AlertDialog mPrompt;
-
+    private File mImagesDir;
 
     @Override
     public void onDestroyView() {
@@ -244,7 +244,7 @@ public class PrintDialog extends DialogFragment implements SimpleTaskWatcher.OnF
         if(includeImages && !App.hasImages()) {
             showInternetUsePrompt();
         } else {
-            PrintPDFTask task = new PrintPDFTask(mTargetTranslation.getId(), mExportFile, includeImages, includeIncompleteFrames);
+            PrintPDFTask task = new PrintPDFTask(mTargetTranslation.getId(), mExportFile, includeImages, includeIncompleteFrames, mImagesDir);
             taskWatcher.watch(task);
             TaskManager.addTask(task, PrintPDFTask.TASK_ID);
         }
@@ -352,8 +352,10 @@ public class PrintDialog extends DialogFragment implements SimpleTaskWatcher.OnF
         TaskManager.clearTask(task);
 
         if(task instanceof DownloadImagesTask) {
-            if (((DownloadImagesTask) task).getSuccess()) {
-                final PrintPDFTask printTask = new PrintPDFTask(mTargetTranslation.getId(), mExportFile, includeImages, includeIncompleteFrames);
+            DownloadImagesTask downloadImagesTask = (DownloadImagesTask) task;
+            if (downloadImagesTask.getSuccess()) {
+                mImagesDir = downloadImagesTask.getImagesDir();
+                final PrintPDFTask printTask = new PrintPDFTask(mTargetTranslation.getId(), mExportFile, includeImages, includeIncompleteFrames, mImagesDir);
                 Handler hand = new Handler(Looper.getMainLooper());
                 hand.post(new Runnable() {
                     @Override

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/PrintDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/PrintDialog.java
@@ -383,6 +383,9 @@ public class PrintDialog extends DialogFragment implements SimpleTaskWatcher.OnF
                 Uri pdfOutputUri = null;
                 boolean success = false;
 
+                String scheme = mDestinationFolderUri.getScheme();
+                isPdfOutputToDocumentFile = !"file".equalsIgnoreCase(scheme);
+
                 // copy PDF to location the user selected
                 if (isPdfOutputToDocumentFile) {
                     try {


### PR DESCRIPTION
Fix #1246 fix image download

Changes in this pull request:
- Restored old Download Images code from older version
- DownloadImagesTask now returns the folder for images.  That folder is now passed into PdfPrinter. PdfPrinter corrected translation format for OBS.
- PrintDialog - fix output when regular folder is selected (not on SD card).
- Upgraded task-manager to 1.5.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1751)
<!-- Reviewable:end -->
