### PR TITLE
Fix v3 migration

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/core/TargetTranslationMigrator.java
+++ b/app/src/main/java/com/door43/translationstudio/core/TargetTranslationMigrator.java
@@ -583,7 +583,8 @@ public class TargetTranslationMigrator {
             manifest.put("package_version", 4);
             FileUtilities.writeStringToFile(manifestFile, manifest.toString(2));
         }
-        migrateChunkChanges(path);
+        String projectSlug = manifest.getString("project_id");
+        migrateChunkChanges(path, projectSlug);
         return path;
     }
 
@@ -666,16 +667,25 @@ public class TargetTranslationMigrator {
      * Merges chunks found in a target translation Project that do not exist in the source translation
      * to a sibling chunk so that no data is lost.
      * @param targetTranslationDir
+     * @param projectSlug
      * @return
      */
-    private static boolean migrateChunkChanges(File targetTranslationDir)  {
+    private static boolean migrateChunkChanges(File targetTranslationDir, String projectSlug)  {
         // TRICKY: calling the App here is bad practice, but we'll deprecate this soon anyway.
         final Door43Client library = App.getLibrary();
-        Project p =  library.index().getProject("en", targetTranslationDir.getName(), true);
+        Project p = library.index().getProject("en", projectSlug, true);
         List<Resource> resources = library.index().getResources(p.languageSlug, p.slug);
         final ResourceContainer resourceContainer;
         try {
-            resourceContainer = library.open(p.languageSlug, p.slug, resources.get(0).slug);
+            Resource resource = null;
+            for (int i = 0; i < resources.size(); i++) {
+                Resource r = resources.get(i);
+                if("book".equalsIgnoreCase(r.type)) {
+                    resource = r;
+                    break;
+                }
+            }
+            resourceContainer = library.open(p.languageSlug, p.slug, resource.slug);
         } catch (Exception e) {
             e.printStackTrace();
             return true;

--- a/app/src/main/java/com/door43/translationstudio/core/TargetTranslationMigrator.java
+++ b/app/src/main/java/com/door43/translationstudio/core/TargetTranslationMigrator.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -728,11 +729,14 @@ public class TargetTranslationMigrator {
                 return !pathname.getName().equals("title.txt") && !pathname.getName().equals("reference.txt");
             }
         });
+        Arrays.sort(frameFiles);
         String invalidChunks = "";
         File lastValidFrameFile = null;
         String chapterId = chapterDir.getName();
         for(File frameFile:frameFiles) {
-            String frameId = frameFile.getName();
+            String frameFileName = frameFile.getName();
+            String[] parts = frameFileName.split(".txt");
+            String frameId = parts[0];
             String chunkText = resourceContainer.readChunk(chapterId, frameId);
             String frameBody = "";
             try {


### PR DESCRIPTION
Fix v3 migration

Changes in this pull request:
 - migrateChunkChanges now looks for project slug in manifest and then finds first "book" resource for chapter list.

@neutrinog

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1755)
<!-- Reviewable:end -->
