### PR TITLE
Fix #1664 save missing verse markers

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/core/TargetTranslationMigrator.java
+++ b/app/src/main/java/com/door43/translationstudio/core/TargetTranslationMigrator.java
@@ -583,8 +583,7 @@ public class TargetTranslationMigrator {
             manifest.put("package_version", 4);
             FileUtilities.writeStringToFile(manifestFile, manifest.toString(2));
         }
-        String projectSlug = manifest.getString("project_id");
-        migrateChunkChanges(path, projectSlug);
+        migrateChunkChanges(path);
         return path;
     }
 
@@ -669,22 +668,14 @@ public class TargetTranslationMigrator {
      * @param targetTranslationDir
      * @return
      */
-    private static boolean migrateChunkChanges(File targetTranslationDir, String projectSlug)  {
+    private static boolean migrateChunkChanges(File targetTranslationDir)  {
         // TRICKY: calling the App here is bad practice, but we'll deprecate this soon anyway.
         final Door43Client library = App.getLibrary();
-        Project p = library.index().getProject("en", projectSlug, true);
+        Project p =  library.index().getProject("en", targetTranslationDir.getName(), true);
         List<Resource> resources = library.index().getResources(p.languageSlug, p.slug);
         final ResourceContainer resourceContainer;
         try {
-            Resource resource = resources.get(0);
-            for (int i = 1; i < resources.size(); i++) {
-                Resource r = resources.get(i);
-                if("book".equalsIgnoreCase(r.type)) {
-                    resource = r;
-                    break;
-                }
-            }
-            resourceContainer = library.open(p.languageSlug, p.slug, resource.slug);
+            resourceContainer = library.open(p.languageSlug, p.slug, resources.get(0).slug);
         } catch (Exception e) {
             e.printStackTrace();
             return true;

--- a/app/src/main/java/com/door43/translationstudio/core/Translator.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Translator.java
@@ -230,6 +230,37 @@ public class Translator {
     }
 
     /**
+     * Compiles all the spannable text back into source that could be either USX or USFM.  It replaces
+     *   the displayed text in spans with their mark-ups.
+     * @param text
+     * @return
+     */
+    public static String compileTranslationSpanned(SpannedString text) {
+        StringBuilder compiledString = new StringBuilder();
+        int next;
+        int lastIndex = 0;
+        for (int i = 0; i < text.length(); i = next) {
+            next = text.nextSpanTransition(i, text.length(), SpannedString.class);
+            SpannedString[] verses = text.getSpans(i, next, SpannedString.class);
+            for (SpannedString s : verses) {
+                int sStart = text.getSpanStart(s);
+                int sEnd = text.getSpanEnd(s);
+                // attach preceeding text
+                if (lastIndex >= text.length() | sStart >= text.length()) {
+                    // out of bounds
+                }
+                compiledString.append(text.toString().substring(lastIndex, sStart));
+                // explode span
+                compiledString.append(s.toString());
+                lastIndex = sEnd;
+            }
+        }
+        // grab the last bit of text
+        compiledString.append(text.toString().substring(lastIndex, text.length()));
+        return compiledString.toString().trim();
+    }
+
+    /**
      * creates a JSON object that contains the manifest.
      * @param targetTranslation
      * @return

--- a/app/src/main/java/com/door43/translationstudio/rendering/ClickableRenderingEngine.java
+++ b/app/src/main/java/com/door43/translationstudio/rendering/ClickableRenderingEngine.java
@@ -54,5 +54,7 @@ public abstract class ClickableRenderingEngine extends RenderingEngine {
     public abstract CharSequence renderVerse(CharSequence in);
 
     public abstract CharSequence getLeadingMajorSectionHeading(CharSequence in);
- }
+
+    public abstract boolean isAddedMissingVerse();
+}
 

--- a/app/src/main/java/com/door43/translationstudio/rendering/RenderingGroup.java
+++ b/app/src/main/java/com/door43/translationstudio/rendering/RenderingGroup.java
@@ -34,6 +34,19 @@ public class RenderingGroup {
     }
 
     /**
+     * see if missing verse was added
+     */
+    public boolean isAddedMissingVerse() {
+        boolean addedMissingVerse = false;
+        for (RenderingEngine engine : mEngines) {
+            if(engine instanceof ClickableRenderingEngine) {
+                addedMissingVerse |= ((ClickableRenderingEngine) engine).isAddedMissingVerse();
+            }
+        }
+        return addedMissingVerse;
+    }
+
+    /**
      * If set to not null matched strings will be highlighted.
      *
      * @param searchString - null is disable

--- a/app/src/main/java/com/door43/translationstudio/rendering/USFMRenderer.java
+++ b/app/src/main/java/com/door43/translationstudio/rendering/USFMRenderer.java
@@ -37,6 +37,7 @@ public class USFMRenderer extends ClickableRenderingEngine {
     private int mHighlightColor = 0;
     private int[] mExpectedVerseRange = new int[0];
     private boolean mSuppressLeadingMajorSectionHeadings = false;
+    private boolean mAddedMissingVerse = false;
 
     /**
      * Creates a new USFM rendering engine without any listeners
@@ -356,6 +357,7 @@ public class USFMRenderer extends ClickableRenderingEngine {
      * @return
      */
     public CharSequence renderVerse(CharSequence in) {
+        mAddedMissingVerse = false;
         CharSequence out = "";
 
         CharSequence insert = "";
@@ -452,6 +454,7 @@ public class USFMRenderer extends ClickableRenderingEngine {
                     }
                     verse.setOnClickListener(mVerseListener);
                     out = TextUtils.concat(verse.toCharSequence(), out);
+                    mAddedMissingVerse = true;
                 }
             } else if (mExpectedVerseRange.length == 2) {
                 for (int i = mExpectedVerseRange[1]; i >= mExpectedVerseRange[0]; i--) {
@@ -465,6 +468,7 @@ public class USFMRenderer extends ClickableRenderingEngine {
                         }
                         verse.setOnClickListener(mVerseListener);
                         out = TextUtils.concat(verse.toCharSequence(), out);
+                        mAddedMissingVerse = true;
                     }
                 }
             }
@@ -651,6 +655,13 @@ public class USFMRenderer extends ClickableRenderingEngine {
      */
     private static Pattern paraShortPattern(String style) {
         return Pattern.compile("<para\\s+style=\""+style+"\"\\s*/>", Pattern.DOTALL); // TODO: 3/1/16 need to upgrade to USFM
+    }
+
+    /**
+     * see if missing verse was added
+     */
+    public boolean isAddedMissingVerse() {
+        return mAddedMissingVerse;
     }
 }
 

--- a/app/src/main/java/com/door43/translationstudio/rendering/USXRenderer.java
+++ b/app/src/main/java/com/door43/translationstudio/rendering/USXRenderer.java
@@ -41,7 +41,7 @@ public class USXRenderer extends ClickableRenderingEngine {
     public static Pattern beginParagraphPattern =  Pattern.compile(beginParagraphStyle);
     public static String endParagraphStyle = "<\\/para>";
     public static Pattern endParagraphPattern =  Pattern.compile(endParagraphStyle);
-
+    private boolean mAddedMissingVerse = false;
 
     /**
      * Creates a new usx rendering engine without any listeners
@@ -342,6 +342,7 @@ public class USXRenderer extends ClickableRenderingEngine {
      * @return
      */
     public CharSequence renderVerse(CharSequence in) {
+        mAddedMissingVerse = false;
         CharSequence out = "";
 
         CharSequence insert = "";
@@ -436,6 +437,7 @@ public class USXRenderer extends ClickableRenderingEngine {
                     }
                     verse.setOnClickListener(mVerseListener);
                     out = TextUtils.concat(verse.toCharSequence(), out);
+                    mAddedMissingVerse = true;
                 }
             } else if (mExpectedVerseRange.length == 2) {
                 for (int i = mExpectedVerseRange[1]; i >= mExpectedVerseRange[0]; i--) {
@@ -449,6 +451,7 @@ public class USXRenderer extends ClickableRenderingEngine {
                         }
                         verse.setOnClickListener(mVerseListener);
                         out = TextUtils.concat(verse.toCharSequence(), out);
+                        mAddedMissingVerse = true;
                     }
                 }
             }
@@ -666,5 +669,12 @@ public class USXRenderer extends ClickableRenderingEngine {
      */
     private static Pattern paraShortPattern(String style) {
         return Pattern.compile("<para\\s+style=\""+style+"\"\\s*/>", Pattern.DOTALL);
+    }
+
+    /**
+     * see if missing verse was added
+     */
+    public boolean isAddedMissingVerse() {
+        return mAddedMissingVerse;
     }
 }

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -690,6 +690,13 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                                         setFinishedMode(item, holder);
                                         ViewUtil.makeLinksClickable(holder.mTargetBody);
                                     }
+
+                                    if(item.hasMissingVerses) {
+                                        if ((item.targetText != null) && !item.targetText.isEmpty()) {
+                                            String translation = applyChangedText(item.renderedTargetText, holder, item);
+                                            item.hasMissingVerses = false;
+                                        }
+                                    }
                                 } else {
                                     Log.i(TAG, "renderTargetCard(): Position " + position + ": ID: " + item.currentTargetTaskId + ": Render failed after delay: task.isCanceled()=" + task.isCanceled() + ", (data==null)=" + (data == null) + ", (item!=holder.currentItem)=" + (item != holder.currentItem));
                                 }
@@ -2184,7 +2191,9 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
         }
         if(!text.trim().isEmpty()) {
             renderingGroup.init(text);
-            return renderingGroup.start();
+            CharSequence results = renderingGroup.start();
+            item.hasMissingVerses = renderingGroup.isAddedMissingVerse();
+            return results;
         } else {
             return "";
         }
@@ -2380,7 +2389,9 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
             }
         }
         renderingGroup.init(text);
-        return renderingGroup.start();
+        CharSequence results = renderingGroup.start();
+        item.hasMissingVerses = renderingGroup.isAddedMissingVerse();
+        return results;
     }
 
     @Override
@@ -2540,6 +2551,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
         public int currentTargetTaskId = -1;
         public int currentResourceTaskId = -1;
         public int currentSourceTaskId = -1;
+        public boolean hasMissingVerses = false;
 
         public ReviewListItem(String chapterSlug, String chunkSlug) {
             super(chapterSlug, chunkSlug);

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -1366,30 +1366,36 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
 
             @Override
             public void onPostExecute() {
-                try {
-                    if(commit != null) {
-                        String text = history.read(commit);
-                        // save and update ui
-                        if (text != null) {
-                            // TRICKY: prevent history from getting rolled back soon after the user views it
-                            restartAutoCommitTimer();
-                            applyChangedText(text, holder, item);
+                if(commit != null) {
+                    String text = null;
+                    try {
+                        text = history.read(commit);
+                    } catch (IllegalStateException e) {
+                        Logger.w(TAG,"Undo is past end of history for specific file", e);
+                        text = ""; // graceful recovery
+                    }catch (Exception e) {
+                        Logger.w(TAG,"Undo Read Exception", e);
+                    }
 
-                            App.closeKeyboard(mContext);
-                            item.hasMergeConflicts = MergeConflictsHandler.isMergeConflicted(text);
-                            triggerNotifyDataSetChanged();
-                            updateMergeConflict();
+                    // save and update ui
+                    if (text != null) {
+                        // TRICKY: prevent history from getting rolled back soon after the user views it
+                        restartAutoCommitTimer();
+                        applyChangedText(text, holder, item);
 
-                            if(holder.mTargetEditableBody != null) {
-                                holder.mTargetEditableBody.removeTextChangedListener(holder.mEditableTextWatcher);
-                                holder.mTargetEditableBody.setText(item.renderedTargetText);
-                                holder.mTargetEditableBody.addTextChangedListener(holder.mEditableTextWatcher);
-                            }
+                        App.closeKeyboard(mContext);
+                        item.hasMergeConflicts = MergeConflictsHandler.isMergeConflicted(text);
+                        triggerNotifyDataSetChanged();
+                        updateMergeConflict();
+
+                        if(holder.mTargetEditableBody != null) {
+                            holder.mTargetEditableBody.removeTextChangedListener(holder.mEditableTextWatcher);
+                            holder.mTargetEditableBody.setText(item.renderedTargetText);
+                            holder.mTargetEditableBody.addTextChangedListener(holder.mEditableTextWatcher);
                         }
                     }
-                } catch (IOException e) {
-                    e.printStackTrace();
                 }
+
                 if(history.hasNext()) {
                     holder.mRedoButton.setVisibility(View.VISIBLE);
                 } else {
@@ -1429,30 +1435,36 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
 
             @Override
             public void onPostExecute() {
-                try {
-                    if(commit != null) {
-                        String text = history.read(commit);
-                        // save and update ui
-                        if (text != null) {
-                            // TRICKY: prevent history from getting rolled back soon after the user views it
-                            restartAutoCommitTimer();
-                            applyChangedText(text, holder, item);
+                if(commit != null) {
+                    String text = null;
+                    try {
+                        text = history.read(commit);
+                    } catch (IllegalStateException e) {
+                        Logger.w(TAG,"Redo is past end of history for specific file", e);
+                        text = ""; // graceful recovery
+                    }catch (Exception e) {
+                        Logger.w(TAG,"Redo Read Exception", e);
+                    }
 
-                            App.closeKeyboard(mContext);
-                            item.hasMergeConflicts = MergeConflictsHandler.isMergeConflicted(text);
-                            triggerNotifyDataSetChanged();
-                            updateMergeConflict();
+                    // save and update ui
+                    if (text != null) {
+                        // TRICKY: prevent history from getting rolled back soon after the user views it
+                        restartAutoCommitTimer();
+                        applyChangedText(text, holder, item);
 
-                            if(holder.mTargetEditableBody != null) {
-                                holder.mTargetEditableBody.removeTextChangedListener(holder.mEditableTextWatcher);
-                                holder.mTargetEditableBody.setText(item.renderedTargetText);
-                                holder.mTargetEditableBody.addTextChangedListener(holder.mEditableTextWatcher);
-                            }
+                        App.closeKeyboard(mContext);
+                        item.hasMergeConflicts = MergeConflictsHandler.isMergeConflicted(text);
+                        triggerNotifyDataSetChanged();
+                        updateMergeConflict();
+
+                        if(holder.mTargetEditableBody != null) {
+                            holder.mTargetEditableBody.removeTextChangedListener(holder.mEditableTextWatcher);
+                            holder.mTargetEditableBody.setText(item.renderedTargetText);
+                            holder.mTargetEditableBody.addTextChangedListener(holder.mEditableTextWatcher);
                         }
                     }
-                } catch (IOException e) {
-                    e.printStackTrace();
                 }
+
                 if(history.hasNext()) {
                     holder.mRedoButton.setVisibility(View.VISIBLE);
                 } else {

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -862,14 +862,19 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
      * if missing verses were found during render, then add them
      * @param item
      * @param holder
+     * @return - returns true if missing verses were applied
      */
-    private void addMissingVerses(ReviewListItem item, ViewHolder holder) {
+    private boolean addMissingVerses(ReviewListItem item, ViewHolder holder) {
         if(item.hasMissingVerses && !item.isComplete) {
             if ((item.targetText != null) && !item.targetText.isEmpty()) {
                 String translation = applyChangedText(item.renderedTargetText, holder, item);
                 item.hasMissingVerses = false;
+                item.renderedTargetText = null; // force rerendering of target text
+                triggerNotifyDataSetChanged();
+                return true;
             }
         }
+        return false;
     }
 
     /**

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -866,8 +866,10 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
      */
     private boolean addMissingVerses(ReviewListItem item, ViewHolder holder) {
         if(item.hasMissingVerses && !item.isComplete) {
+            Log.i(TAG, "Adding Missing verses to: " + item.targetText);
             if ((item.targetText != null) && !item.targetText.isEmpty()) {
                 String translation = applyChangedText(item.renderedTargetText, holder, item);
+                Log.i(TAG, "Added Missing verses: " + translation);
                 item.hasMissingVerses = false;
                 item.renderedTargetText = null; // force rerendering of target text
                 triggerNotifyDataSetChanged();


### PR DESCRIPTION
Fix #1664 save missing verse markers

Changes in this pull request:
- changed render functions to save flag that missing verses were added.
- in review mode adapter added flag to ReviewListItem for missing verses added.  When render has completed we check if missing verses were added.  If so, then we apply changes and trigger a new render.
- in Translator, added compileTranslationSpanned() to compile SpannedString.
- Fixed crash when undo moves back before a chunk file existed. There was an unhandled exception from core.  ReviewListItem nows captures that exception and gracefully recovers by replacing content with empty string.

@neutrinog

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1756)
<!-- Reviewable:end -->
