### PR TITLE
Fix #1505 QA fail - remove second save

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/PrintDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/PrintDialog.java
@@ -382,6 +382,7 @@ public class PrintDialog extends DialogFragment implements SimpleTaskWatcher.OnF
                 File pdfOutputFolder = null;
                 Uri pdfOutputUri = null;
                 boolean success = false;
+                String pdfDestination = "";
 
                 String scheme = mDestinationFolderUri.getScheme();
                 isPdfOutputToDocumentFile = !"file".equalsIgnoreCase(scheme);
@@ -397,6 +398,7 @@ public class PrintDialog extends DialogFragment implements SimpleTaskWatcher.OnF
                         int bytes = FileUtilities.copy(fis, bufferedOutputStream);
                         bufferedOutputStream.close();
                         fis.close();
+                        pdfDestination = SdUtils.getPathString(sdCardFile);
                         success = true;
                     } catch (Exception e) {
                         Logger.e(TAG, "Failed to copy the PDF file to: " + pdfOutputUri, e);
@@ -406,6 +408,7 @@ public class PrintDialog extends DialogFragment implements SimpleTaskWatcher.OnF
                     try {
                         pdfOutputFolder = new File(mDestinationFolderUri.getPath(), mDestinationFilename);
                         FileUtilities.copyFile(mExportFile, pdfOutputFolder);
+                        pdfDestination = pdfOutputFolder.toString();
                         success = true;
                     } catch (IOException e) {
                         Logger.e(TAG, "Failed to copy the PDF file to: " + pdfOutputFolder, e);
@@ -413,12 +416,12 @@ public class PrintDialog extends DialogFragment implements SimpleTaskWatcher.OnF
                 }
 
                 if(success) {
-                    // send to print provider
-                    Uri u = FileProvider.getUriForFile(App.context(), "com.door43.translationstudio.fileprovider", mExportFile);
-                    Intent i = new Intent(Intent.ACTION_SEND);
-                    i.setType("application/pdf");
-                    i.putExtra(Intent.EXTRA_STREAM, u);
-                    startActivity(Intent.createChooser(i, "Print:"));
+                    String message = getActivity().getResources().getString(R.string.print_success, pdfDestination);
+                    new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
+                            .setTitle(R.string.success)
+                            .setMessage(message)
+                            .setPositiveButton(R.string.dismiss, null)
+                            .show();
                     return;
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -949,4 +949,5 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
     <string name="found_in_chunks">Found in <xliff:g example="6" id="found_count">%1$d</xliff:g> chunks</string>
     <string name="retry_label">Retry</string>
     <string name="current_user">Current User: <xliff:g example="tester" id="user_name">%1$s</xliff:g></string>
+    <string name="print_success">Print successfully saved to:\n<xliff:g example="/downloads/en_ulb.pdf" id="destination">%1$s</xliff:g></string>
 </resources>


### PR DESCRIPTION
Fix #1505 QA fail - remove second save

Changes in this pull request:
- Removed pdf chooser at end of Print.  
- Added print success dialog that displays path to file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1784)
<!-- Reviewable:end -->
