### PR TITLE
Fix #1593 QA fail - persist sort options on home page

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/home/TargetTranslationAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/TargetTranslationAdapter.java
@@ -312,6 +312,23 @@ public class TargetTranslationAdapter extends BaseAdapter implements ManagedTask
             return _value;
         }
 
+        public static SortByColumnType fromString(String value, SortByColumnType defaultValue ) {
+            Integer returnValue = null;
+            if(value != null) {
+                try {
+                    returnValue = Integer.valueOf(value);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+
+            if(returnValue == null) {
+                return defaultValue;
+            }
+
+            return fromInt(returnValue);
+        }
+
         public static SortByColumnType fromInt(int i) {
             for (SortByColumnType b : SortByColumnType.values()) {
                 if (b.getValue() == i) {
@@ -337,6 +354,23 @@ public class TargetTranslationAdapter extends BaseAdapter implements ManagedTask
 
         public int getValue() {
             return _value;
+        }
+
+        public static SortProjectColumnType fromString(String value, SortProjectColumnType defaultValue ) {
+            Integer returnValue = null;
+            if(value != null) {
+                try {
+                    returnValue = Integer.valueOf(value);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+
+            if(returnValue == null) {
+                return defaultValue;
+            }
+
+            return fromInt(returnValue);
         }
 
         public static SortProjectColumnType fromInt(int i) {

--- a/app/src/main/java/com/door43/translationstudio/ui/home/TargetTranslationListFragment.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/TargetTranslationListFragment.java
@@ -79,7 +79,7 @@ public class TargetTranslationListFragment extends BaseFragment implements Targe
         if(savedInstanceState != null) {
             mSortByColumn = TargetTranslationAdapter.SortByColumnType.fromInt(savedInstanceState.getInt(STATE_SORT_BY_COLUMN, mSortByColumn.getValue()));
             mSortProjectColumn = TargetTranslationAdapter.SortProjectColumnType.fromInt(savedInstanceState.getInt(STATE_SORT_PROJECT_COLUMN, mSortProjectColumn.getValue()));
-        } else { // if not restoring states, get default
+        } else { // if not restoring states, get last values
             mSortByColumn = TargetTranslationAdapter.SortByColumnType.fromString(App.getUserString(SORT_BY_COLUMN_ITEM, null), TargetTranslationAdapter.SortByColumnType.projectThenLanguage);
             mSortProjectColumn = TargetTranslationAdapter.SortProjectColumnType.fromString(App.getUserString(SORT_PROJECT_ITEM, null), TargetTranslationAdapter.SortProjectColumnType.bibleOrder);
         }

--- a/app/src/main/java/com/door43/translationstudio/ui/home/TargetTranslationListFragment.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/TargetTranslationListFragment.java
@@ -30,6 +30,8 @@ public class TargetTranslationListFragment extends BaseFragment implements Targe
     public static final String TAG = TargetTranslationListFragment.class.getSimpleName();
     public static final String STATE_SORT_BY_COLUMN = "state_sort_by_column";
     public static final String STATE_SORT_PROJECT_COLUMN = "state_sort_project_column";
+    public static final String SORT_PROJECT_ITEM = "sort_project_item";
+    public static final String SORT_BY_COLUMN_ITEM = "sort_by_column_item";
     private TargetTranslationAdapter mAdapter;
     private OnItemClickListener mListener;
     private TargetTranslationAdapter.SortProjectColumnType mSortProjectColumn = TargetTranslationAdapter.SortProjectColumnType.bibleOrder;
@@ -77,6 +79,9 @@ public class TargetTranslationListFragment extends BaseFragment implements Targe
         if(savedInstanceState != null) {
             mSortByColumn = TargetTranslationAdapter.SortByColumnType.fromInt(savedInstanceState.getInt(STATE_SORT_BY_COLUMN, mSortByColumn.getValue()));
             mSortProjectColumn = TargetTranslationAdapter.SortProjectColumnType.fromInt(savedInstanceState.getInt(STATE_SORT_PROJECT_COLUMN, mSortProjectColumn.getValue()));
+        } else { // if not restoring states, get default
+            mSortByColumn = TargetTranslationAdapter.SortByColumnType.fromString(App.getUserString(SORT_BY_COLUMN_ITEM, null), TargetTranslationAdapter.SortByColumnType.projectThenLanguage);
+            mSortProjectColumn = TargetTranslationAdapter.SortProjectColumnType.fromString(App.getUserString(SORT_PROJECT_ITEM, null), TargetTranslationAdapter.SortProjectColumnType.bibleOrder);
         }
         mAdapter.sort(mSortByColumn, mSortProjectColumn);
 
@@ -95,6 +100,7 @@ public class TargetTranslationListFragment extends BaseFragment implements Targe
                 public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
                     Logger.i(TAG, "Sort column item selected: " + position);
                     mSortByColumn = TargetTranslationAdapter.SortByColumnType.fromInt(position);
+                    App.setUserString(SORT_BY_COLUMN_ITEM, String.valueOf(mSortByColumn.getValue()));
                     if(mAdapter != null) {
                         mAdapter.sort(mSortByColumn, mSortProjectColumn);
                     }
@@ -120,6 +126,7 @@ public class TargetTranslationListFragment extends BaseFragment implements Targe
                 public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
                     Logger.i(TAG, "Sort project column item selected: " + position);
                     mSortProjectColumn = TargetTranslationAdapter.SortProjectColumnType.fromInt(position);
+                    App.setUserString(SORT_PROJECT_ITEM, String.valueOf(mSortProjectColumn.getValue()));
                     if(mAdapter != null) {
                         mAdapter.sort(mSortByColumn, mSortProjectColumn);
                     }


### PR DESCRIPTION
Fix #1593 persist sort options on home page

Changes in this pull request:
- Preserve last sort options on home page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1785)
<!-- Reviewable:end -->
