### PR TITLE
Fix #1690 QA fail - change text on update dialog

### DIFF
--- a/app/src/main/res/layout/dialog_update_library.xml
+++ b/app/src/main/res/layout/dialog_update_library.xml
@@ -97,16 +97,6 @@
                     android:duplicateParentState="true"
                     style="@style/Widget.Alert.Button.Secondary"/>
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/time_fast"
-                    android:textColor="@color/dark_secondary_text"
-                    android:focusable="false"
-                    android:clickable="false"
-                    android:duplicateParentState="true"
-                    android:textSize="@dimen/caption"
-                    android:layout_marginLeft="@dimen/dialog_content_margin" />
             </LinearLayout>
 
             <LinearLayout
@@ -169,16 +159,6 @@
                     android:duplicateParentState="true"
                     style="@style/Widget.Alert.Button.Secondary"/>
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/time_fast"
-                    android:textColor="@color/dark_secondary_text"
-                    android:focusable="false"
-                    android:clickable="false"
-                    android:duplicateParentState="true"
-                    android:layout_marginLeft="@dimen/dialog_content_margin"
-                    android:textSize="@dimen/caption"/>
             </LinearLayout>
 
             <LinearLayout


### PR DESCRIPTION
Fix #1690 QA fail - change text on update dialog

Changes in this pull request:
- Remove redundant warning of download times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1786)
<!-- Reviewable:end -->
