### PR TITLE
Fix #1689 QA Fail - add cancel download source

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
@@ -599,9 +599,10 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
 
     @Override
     public void onTaskFinished(final ManagedTask task) {
+        final boolean canceled = task.isCanceled();
         TaskManager.clearTask(task);
 
-        if((getActivity() == null) || (task.isCanceled())) {
+        if(getActivity() == null) {
             return; // if activity changed
         }
 
@@ -610,20 +611,23 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
             @Override
             public void run() {
                 if(task instanceof GetAvailableSourcesTask) {
-                    mGetAvailableTaskID = -1;
-                    GetAvailableSourcesTask availableSourcesTask = (GetAvailableSourcesTask) task;
-                    mAdapter.setData(availableSourcesTask);
-                    if(mSelected != null) {
-                        mAdapter.setSelected(mSelected);
-                        mAdapter.initializeSelections();
-                        onSelectionChanged();
-                    }
-                    if(mSearchString != null) {
-                        enableSearchText();
-                        mSearchEditText.setText(mSearchString);
-                        int endPos = mSearchString.length();
-                        mSearchEditText.setSelection(endPos,endPos);
-                        mAdapter.setSearch(mSearchString);
+
+                    if(!canceled) {
+                        mGetAvailableTaskID = -1;
+                        GetAvailableSourcesTask availableSourcesTask = (GetAvailableSourcesTask) task;
+                        mAdapter.setData(availableSourcesTask);
+                        if(mSelected != null) {
+                            mAdapter.setSelected(mSelected);
+                            mAdapter.initializeSelections();
+                            onSelectionChanged();
+                        }
+                        if(mSearchString != null) {
+                            enableSearchText();
+                            mSearchEditText.setText(mSearchString);
+                            int endPos = mSearchString.length();
+                            mSearchEditText.setSelection(endPos, endPos);
+                            mAdapter.setSearch(mSearchString);
+                        }
                     }
 
                     if (mProgressDialog != null) {
@@ -652,7 +656,6 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
                         }
                     }
 
-                    boolean canceled = downloadSourcesTask.isCanceled();
                     String downloads = getActivity().getResources().getString(R.string.downloads_success,downloadedContainers.size());
                     String errors = "";
                     if((failed.size() > 0) && !canceled) {

--- a/app/src/main/java/com/door43/translationstudio/ui/home/HomeActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/HomeActivity.java
@@ -87,6 +87,7 @@ public class HomeActivity extends BaseActivity implements SimpleTaskWatcher.OnFi
     private String mTargetTranslationWithUpdates;
     private String mTargetTranslationID;
     private ProgressDialog progressDialog = null;
+    private UpdateLibraryDialog mUpdateDialog = null;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -144,8 +145,8 @@ public class HomeActivity extends BaseActivity implements SimpleTaskWatcher.OnFi
                     public boolean onMenuItemClick(MenuItem item) {
                         switch (item.getItemId()) {
                             case R.id.action_update:
-                                UpdateLibraryDialog updateDialog = new UpdateLibraryDialog();
-                                showDialogFragment(updateDialog, UpdateLibraryDialog.TAG);
+                                mUpdateDialog = new UpdateLibraryDialog();
+                                showDialogFragment(mUpdateDialog, UpdateLibraryDialog.TAG);
                                 return true;
                             case R.id.action_import:
                                 ImportDialog importDialog = new ImportDialog();
@@ -773,8 +774,8 @@ public class HomeActivity extends BaseActivity implements SimpleTaskWatcher.OnFi
             snack.setAction(R.string.check_for_updates, new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    UpdateLibraryDialog updateDialog = new UpdateLibraryDialog();
-                    showDialogFragment(updateDialog, updateDialog.TAG);
+                    mUpdateDialog = new UpdateLibraryDialog();
+                    showDialogFragment(mUpdateDialog, mUpdateDialog.TAG);
                 }
             });
             snack.setActionTextColor(getResources().getColor(R.color.light_primary_text));
@@ -865,6 +866,10 @@ public class HomeActivity extends BaseActivity implements SimpleTaskWatcher.OnFi
             task.addOnProgressListener(this);
             task.addOnFinishedListener(this);
             TaskManager.addTask(task, taskId);
+
+            if(mUpdateDialog != null) {
+                mUpdateDialog.dismiss();
+            }
         }
     }
 


### PR DESCRIPTION
Fix #1689 QA Fail - add cancel download source

Changes in this pull request:
- Fixed flawed logic that caused nothing to be shown with Download was cancelled.  Worked on logic to distinguish between  dialog being closed and download being cancelled.
- Fixed issue that sometimes on rotation the Update dialog would be on top.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1790)
<!-- Reviewable:end -->
