### PR TITLE
Fix #1605 QA Fail - uploading with merge conflict

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/core/MergeConflictsHandler.java
+++ b/app/src/main/java/com/door43/translationstudio/core/MergeConflictsHandler.java
@@ -152,6 +152,7 @@ public class MergeConflictsHandler {
                 }
             }
         });
+        TaskManager.addTask(task);
     }
 
     public interface OnMergeConflictListener {

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
@@ -725,14 +725,8 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
         mDialogShown = eDialogShown.MERGE_CONFLICT;
 
         String projectID = targetTranslation.getProjectId();
-        Project project = App.getLibrary().index().getProject(targetTranslation.getTargetLanguage().slug, projectID);
-        if(project == null) {
-            Logger.e(TAG, "invalid project id:" + projectID);
-            return;
-        }
-
         String message = String.format(getResources().getString(R.string.merge_request),
-                project.name, targetTranslation.getTargetLanguageName());
+                projectID, targetTranslation.getTargetLanguageName());
 
         new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
                 .setTitle(R.string.change_detected)
@@ -759,7 +753,7 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
      */
     private void doManualMerge() {
         if(getActivity() instanceof TargetTranslationActivity) {
-            ((TargetTranslationActivity) getActivity()).notifyDatasetChanged();
+            ((TargetTranslationActivity) getActivity()).redrawTarget();
             BackupDialog.this.dismiss();
             // TODO: 4/20/16 it would be nice to navigate directly to the first conflict
         } else {

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
@@ -1162,7 +1162,16 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
      */
     public void notifyDatasetChanged() {
         if (mFragment instanceof ViewModeFragment && ((ViewModeFragment) mFragment).getAdapter() != null) {
-            ((ViewModeFragment) mFragment).getAdapter().notifyDataSetChanged();
+            ((ViewModeFragment) mFragment).getAdapter().triggerNotifyDataSetChanged();
+        }
+    }
+
+    /**
+     * Causes the activity to tell the fragment that everything needs to be redrawn
+     */
+    public void redrawTarget() {
+        if (mFragment instanceof ViewModeFragment) {
+            ((ViewModeFragment) mFragment).onResume();
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -842,7 +842,7 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
     <string name="view_online">View Online</string>
     <string name="change_detected">Project Change Detected</string>
     <string name="upload_push_failure">There are changes to this translation on your Door43 account. You must import those changes before uploading.</string>
-    <string name="merge_request">There are changes to your translation of <xliff:g example="Hebrews" id="book">%1$s</xliff:g> in <xliff:g example="English" id="language">%2$s</xliff:g> on your Door43 account. Would you like to import those changes now?</string>
+    <string name="merge_request">There are changes to your translation of \'<xliff:g example="Hebrews" id="book">%1$s</xliff:g>\' in \'<xliff:g example="English" id="language">%2$s</xliff:g>\' on your Door43 account. Would you like to import those changes now?</string>
     <string name="import_failed_title">Import failed</string>
     <string name="push_rejected">Upload failed because of changes on Server. Do you want to review conflicts?</string>
     <string name="backup_rejected">Backup failed because of changes on Server. Do you want to review conflicts?</string>


### PR DESCRIPTION
Fix #1605 uploading with merge conflict

Changes in this pull request:
- Fixed issue that MergeConflictsHandler task was not starting.  
- Fixed bug with getting projectID.  
- Fixed issue that merge conflicts were not being redrawn when upload was done while editing translation.  Worked better calling onResume() of fragment than notify data changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1795)
<!-- Reviewable:end -->
