### PR TITLE
Fix #1664 QA fail - verse markers not saved after drag.

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ListItem.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ListItem.java
@@ -177,32 +177,40 @@ public abstract class ListItem {
             }
             this.sourceTranslationFormat = TranslationFormat.parse(sourceContainer.contentMimeType);
             this.targetTranslationFormat = targetTranslation.getFormat();
-            // TODO: 10/1/16 this will be simplified once we migrate target translations to resource containers
-            if (chapterSlug.equals("front")) {
-                // project stuff
-                if (chunkSlug.equals("title")) {
-                    this.targetText = pt.getTitle();
-                    this.isComplete = pt.isTitleFinished();
-                }
-            } else if (chapterSlug.equals("back")) {
-                // back matter
-
-            } else {
-                // chapter stuff
-                this.ct = targetTranslation.getChapterTranslation(chapterSlug);
-                if (chunkSlug.equals("title")) {
-                    this.targetText = ct.title;
-                    this.isComplete = ct.isTitleFinished();
-                } else if (chunkSlug.equals("reference")) {
-                    this.targetText = ct.reference;
-                    this.isComplete = ct.isReferenceFinished();
-                } else {
-                    this.ft = targetTranslation.getFrameTranslation(chapterSlug, chunkSlug, this.targetTranslationFormat);
-                    this.targetText = ft.body;
-                    this.isComplete = ft.isFinished();
-                }
-            }
-            this.hasMergeConflicts = MergeConflictsHandler.isMergeConflicted(this.targetText);
+            loadTarget(targetTranslation);
         }
+    }
+
+    /**
+     * used for reloading target translation to get any changes from file
+     * @param targetTranslation
+     */
+    public void loadTarget(TargetTranslation targetTranslation) {
+        // TODO: 10/1/16 this will be simplified once we migrate target translations to resource containers
+        if (chapterSlug.equals("front")) {
+            // project stuff
+            if (chunkSlug.equals("title")) {
+                this.targetText = pt.getTitle();
+                this.isComplete = pt.isTitleFinished();
+            }
+        } else if (chapterSlug.equals("back")) {
+            // back matter
+
+        } else {
+            // chapter stuff
+            this.ct = targetTranslation.getChapterTranslation(chapterSlug);
+            if (chunkSlug.equals("title")) {
+                this.targetText = ct.title;
+                this.isComplete = ct.isTitleFinished();
+            } else if (chunkSlug.equals("reference")) {
+                this.targetText = ct.reference;
+                this.isComplete = ct.isReferenceFinished();
+            } else {
+                this.ft = targetTranslation.getFrameTranslation(chapterSlug, chunkSlug, this.targetTranslationFormat);
+                this.targetText = ft.body;
+                this.isComplete = ft.isFinished();
+            }
+        }
+        this.hasMergeConflicts = MergeConflictsHandler.isMergeConflicted(this.targetText);
     }
 }

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -771,7 +771,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                     mgr.showSoftInput(holder.mTargetEditableBody, InputMethodManager.SHOW_IMPLICIT);
 
                     // TRICKY: there may be changes to translation
-                     item.load(mSourceContainer, mTargetTranslation);
+                    item.loadTarget(mTargetTranslation);
 
                     // re-render for editing mode
                     item.renderedTargetText = renderSourceText(item.targetText, item.targetTranslationFormat, holder, item, true);
@@ -786,7 +786,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                     getListener().closeKeyboard();
 
                     // TRICKY: there may be changes to translation
-                    item.load(mSourceContainer, mTargetTranslation);
+                    item.loadTarget(mTargetTranslation);
 
                     // re-render for verse mode
                     item.renderedTargetText = renderTargetText(item.targetText, item.targetTranslationFormat, item.ft, holder, item);
@@ -2177,8 +2177,8 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                                 String translation = Translator.compileTranslation((Editable)editText.getText());
                                 mTargetTranslation.applyFrameTranslation(frameTranslation, translation);
 
-                                // Reload, so that targetText and other data are kept in sync.
-                                item.load(mSourceContainer, mTargetTranslation);
+                                // Reload, so that targetText is kept in sync.
+                                item.loadTarget(mTargetTranslation);
                             } else if(event.getAction() == DragEvent.ACTION_DRAG_ENDED) {
                                 view.setOnDragListener(null);
                                 editText.setSelection(editText.getSelectionEnd());
@@ -2193,8 +2193,8 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                                     String translation = Translator.compileTranslation((Editable)editText.getText());
                                     mTargetTranslation.applyFrameTranslation(frameTranslation, translation);
 
-                                    // Reload, so that targetText and other data are kept in sync.
-                                    item.load(mSourceContainer, mTargetTranslation);
+                                    // Reload, so that targetText is kept in sync.
+                                    item.loadTarget(mTargetTranslation);
                                 }
                             } else if(event.getAction() == DragEvent.ACTION_DRAG_ENTERED) {
                                 hasEntered = true;


### PR DESCRIPTION
Fix #1664 QA fail - verse markers not saved after drag.

Changes in this pull request:
- ListItem - created separate method for just reloading target from file to be called after edit was made to chunk.  Previously would just call load(), but that would only do something if source was null.  The new loadTarget() method will always reload target text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1838)
<!-- Reviewable:end -->
