### PR TITLE
Fix #1505 QA fail - Download Images for OBS printing appears hung after download

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/tasks/DownloadImagesTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/DownloadImagesTask.java
@@ -33,13 +33,8 @@ public class DownloadImagesTask extends ManagedTask {
             mSuccess = downloadImages.download(new DownloadImages.OnProgressListener() {
 
                 @Override
-                public boolean onProgress(int progress, int max) {
+                public boolean onProgress(int progress, int max, String message) {
                     mMaxProgress = max;
-                    String message = String.format("%2.2f %s %2.2f %s",
-                            progress / (1024f * 1024f),
-                            App.context().getResources().getString(R.string.out_of),
-                            max / (1024f * 1024f),
-                            App.context().getResources().getString(R.string.mb_downloaded));
                     publishProgress((float) progress / (float) max, message);
                     return !isCanceled();
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -953,4 +953,5 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
     <string name="check_network_connection">Check your internet and try again</string>
     <string name="upload_complete">Upload Complete</string>
     <string name="import_usfm_merge_conflict">Project already exists - Click Continue to merge and resolve conflicts.</string>
+    <string name="unpacking">Unpacking Images</string>
 </resources>


### PR DESCRIPTION
Fix #1505 QA fail - Download Images for OBS printing appears hung after download

Changes in this pull request:
- DownloadImages: added more detail to progress.  Now shows unzipping progress so that user doesn't think app has hung after download.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1840)
<!-- Reviewable:end -->
