### PR TITLE
Fix #1689 QA Fail - Only show source download success if helps also downloaded

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
@@ -35,14 +35,11 @@ import com.door43.translationstudio.App;
 import com.door43.translationstudio.R;
 import com.door43.translationstudio.tasks.DownloadResourceContainersTask;
 import com.door43.translationstudio.tasks.GetAvailableSourcesTask;
-import com.door43.translationstudio.ui.home.HomeActivity;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.unfoldingword.door43client.Door43Client;
-import org.unfoldingword.door43client.models.Translation;
-import org.unfoldingword.resourcecontainer.ResourceContainer;
 import org.unfoldingword.tools.logger.Logger;
 import org.unfoldingword.tools.taskmanager.ManagedTask;
 import org.unfoldingword.tools.taskmanager.TaskManager;
@@ -658,19 +655,19 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
                     }
 
                     DownloadResourceContainersTask downloadSourcesTask = (DownloadResourceContainersTask) task;
-                    List<ResourceContainer> downloadedContainers = downloadSourcesTask.getDownloadedContainers();
+                    List<String> downloadedTranslations = downloadSourcesTask.getDownloadedTranslations();
 
-                    for (ResourceContainer container : downloadedContainers) {
-                        Logger.i(TAG, "Received: " + container.slug);
+                    for (String slug : downloadedTranslations) {
+                        Logger.i(TAG, "Received: " + slug);
 
-                        int pos = mAdapter.findPosition(container.slug);
+                        int pos = mAdapter.findPosition(slug);
                         if(pos >= 0) {
                             mAdapter.markItemDownloaded(pos);
                         }
                     }
 
-                    List<String> failed = downloadSourcesTask.getFailedDownloads();
-                    for (String translationID : failed) {
+                    List<String> failedSourceDownloads = downloadSourcesTask.getFailedSourceDownloads();
+                    for (String translationID : failedSourceDownloads) {
                         Logger.e(TAG, "Download failed: " + translationID);
                         int pos = mAdapter.findPosition(translationID);
                         if(pos >= 0) {
@@ -678,10 +675,10 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
                         }
                     }
 
-                    String downloads = getActivity().getResources().getString(R.string.downloads_success,downloadedContainers.size());
+                    String downloads = getActivity().getResources().getString(R.string.downloads_success,downloadedTranslations.size());
                     String errors = "";
-                    if((failed.size() > 0) && !canceled) {
-                        errors = "\n" + getActivity().getResources().getString(R.string.downloads_fail, failed.size());
+                    if((failedSourceDownloads.size() > 0) && !canceled) {
+                        errors = "\n" + getActivity().getResources().getString(R.string.downloads_fail, failedSourceDownloads.size());
                     }
 
                     List<String> failedNotesDownloads = downloadSourcesTask.getFailedNotesDownloads();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -931,7 +931,7 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
     <string name="select_all_label">Select All</string>
     <string name="unselect_all_label">Unselect All</string>
     <string name="downloads_success"><xliff:g example="6" id="success_count">%1$d</xliff:g> Source Texts have been successfully downloaded.</string>
-    <string name="downloads_fail"><xliff:g example="6" id="fail_count">%1$d</xliff:g> download attempts have failed.</string>
+    <string name="downloads_fail"><xliff:g example="6" id="fail_count">%1$d</xliff:g> Source downloads have failed.</string>
     <string name="download_cancelled">Download Cancelled</string>
     <string name="download_errors">Download Errors</string>
     <string name="notes_download_errors">Notes failed to download for: <xliff:g example="en_obs,fr_obs" id="fails">%1$s</xliff:g></string>


### PR DESCRIPTION
Fix #1689 QA Fail - Only show source download success if helps also downloaded

Changes in this pull request:
- DownloadResourceContainersTask: changed to keep track of sources download with helps. If help fails, then mark everything as failed. Fix to show progress on first download. Add update of display when downloading helps.
- DownloadSourcesDialog: now shows successes and failures if complete source.  Source download is only successful if helps also downloads.  If error downloading helps then source download is considered download error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1847)
<!-- Reviewable:end -->
