### PR TITLE
Fix #1827 Printing shows id tags if USFM import

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
         applicationId "com.translationstudio.androidapp"
         minSdkVersion 15
         targetSdkVersion 23
-        versionCode 153
+        versionCode 154
         versionName "11.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     } 

--- a/app/src/androidTest/java/com/door43/translationstudio/core/ExportUsfmTest.java
+++ b/app/src/androidTest/java/com/door43/translationstudio/core/ExportUsfmTest.java
@@ -635,9 +635,18 @@ public class ExportUsfmTest extends InstrumentationTestCase {
             for(int j = 0; j < limit; j++) {
                 String tocVerse = tocChunks.get(j+offset);
                 String versificationVerse = versificationChunks.get(j);
-                if(strToInt(tocVerse,-1) != strToInt(versificationVerse,-1)) {
-                    addErrorMsg("For chapter '" + chapterSlug + "' toc chunk " + i + " is '" + tocVerse + "' but versification chunk is '" + versificationVerse + "'\n");
-                    chunkErrors = true;
+                int tocVerseNumber = strToInt(tocVerse, -1);
+                if(tocVerseNumber != strToInt(versificationVerse,-1)) {
+                    boolean atLastChunk = false;
+                    boolean atLastChapter = (i == (sourceToc.size()-1));
+                    if(atLastChapter) {
+                        atLastChunk = (j == limit - 1);
+                    }
+
+                    if(atLastChunk && (tocVerseNumber != 0)) {
+                        addErrorMsg("For chapter '" + chapterSlug + "' toc chunk " + i + " is '" + tocVerse + "' but versification chunk is '" + versificationVerse + "'\n");
+                        chunkErrors = true;
+                    }
                 }
             }
 

--- a/app/src/main/java/com/door43/translationstudio/core/ExportUsfm.java
+++ b/app/src/main/java/com/door43/translationstudio/core/ExportUsfm.java
@@ -249,6 +249,10 @@ public class ExportUsfm {
                 }
             }
             if(bookTitle.isEmpty()) {
+                bookTitle = bookName;
+            }
+
+            if(bookTitle.isEmpty()) {
                 bookTitle = bookCode;
             }
 

--- a/app/src/main/java/com/door43/translationstudio/core/ExportUsfm.java
+++ b/app/src/main/java/com/door43/translationstudio/core/ExportUsfm.java
@@ -82,6 +82,12 @@ public class ExportUsfm {
             boolean needNewFile = (ps == null);
             if(needNewFile) {
                 BookData bookData = BookData.generate(targetTranslation);
+                String bookCode = bookData.getBookCode();
+                String bookTitle = bookData.getBookTitle();
+                String bookName = bookData.getBookName();
+                String languageId = bookData.getLanguageId();
+                String languageName = bookData.getLanguageName();
+
                 if((fileName != null) && (!fileName.isEmpty())) {
                     outputFileName = fileName;
                 } else {
@@ -95,6 +101,15 @@ public class ExportUsfm {
                     ps.close();
                 }
                 ps = new PrintStream(tempFile);
+
+                String id = "\\id " + bookCode + " " + bookTitle + ", " + bookName + ", " + (languageId + ", " + languageName);
+                ps.println(id);
+                String bookID = "\\toc1 " + bookTitle;
+                ps.println(bookID);
+                String bookNameID = "\\toc2 " + bookName;
+                ps.println(bookNameID);
+                String shortBookID = "\\toc3 " + bookCode;
+                ps.println(shortBookID);
             }
 
             int chapterInt = Util.strToInt(chapter.getId(),0);

--- a/app/src/main/java/com/door43/translationstudio/core/ImportUsfm.java
+++ b/app/src/main/java/com/door43/translationstudio/core/ImportUsfm.java
@@ -1087,11 +1087,14 @@ public class ImportUsfm {
                 return false;
             }
         } else { // save stuff before first chapter
-            String chapter0 = "00"; // chapter "00" folder contains stuff that applies to the whole book, like title
-            success = saveSection("front", "intro", cleanedString);
-            successOverall = successOverall && success;
-            success = saveSection(chapter0, "title", mBookName);
-            successOverall = successOverall && success;
+            String strippedUsfmFrontTags = removeKnownUsfmTags(cleanedString);
+            if(strippedUsfmFrontTags.length() > 0) {
+                String chapter0 = "00"; // chapter "00" folder contains stuff that applies to the whole book, like title
+                success = saveSection("front", "intro", strippedUsfmFrontTags);
+                successOverall = successOverall && success;
+                success = saveSection(chapter0, "title", mBookName);
+                successOverall = successOverall && success;
+            }
         }
         return successOverall;
     }
@@ -1530,6 +1533,102 @@ public class ImportUsfm {
         }
 
         return null;
+    }
+
+    /**
+     * match regexPattern for USFM line and remove line if present
+     *
+     * @param text
+     * @return
+     */
+    private String removeKnownUsfmTags(CharSequence text) {
+        if (text.length() > 0) {
+            final String USFM_TAG = "\\\\([\\w\\d]+)\\s([^\\n\\\\]*)";
+            Pattern regexPattern = Pattern.compile(USFM_TAG);
+
+            // find instance
+            Matcher matcher = regexPattern.matcher(text);
+            CharSequence cleaned = "";
+            int lastPos = 0;
+            while (matcher.find()) {
+                CharSequence usfmTag = matcher.group(1);
+
+                if( (usfmTag.equals("c"))
+                        || (usfmTag.equals("id"))
+                        || (usfmTag.equals("ide"))
+                        || (usfmTag.equals("h"))
+                        || (usfmTag.equals("toc1"))
+                        || (usfmTag.equals("toc2"))
+                        || (usfmTag.equals("toc3"))
+                        || (usfmTag.equals("mt"))
+                        || (usfmTag.equals("p"))
+                        ) {
+
+                    CharSequence before = text.subSequence(lastPos, matcher.start());
+                    lastPos = matcher.end();
+                    if(lastPos < text.length()) {
+                        char c = text.charAt(lastPos);
+                        if (c == '\n') {
+                            lastPos++;
+                        }
+                    }
+
+                    cleaned = TextUtils.concat(cleaned, before);
+                }
+            }
+            if(lastPos < text.length()) {
+                cleaned = TextUtils.concat(cleaned, text.subSequence(lastPos, text.length()));
+            }
+            CharSequence trimmed = trimWhiteSpace(cleaned);
+            return trimmed.toString();
+        }
+        return "";
+    }
+
+    /**
+     * trims leading and trailing white space
+     * @param text
+     * @return
+     */
+    private CharSequence trimWhiteSpace(CharSequence text) {
+        int pos = 0;
+        while(pos < text.length()) {
+            char c = text.charAt(pos);
+            if( (c == ' ') || (c == '\n') ) {
+                pos++;
+            } else {
+                break;
+            }
+        }
+
+        if(pos >= text.length()) {
+            return "";
+        }
+
+        CharSequence trimmed = text.subSequence(pos, text.length());
+
+        pos = trimmed.length();
+        while(pos > 0) {
+            char c = trimmed.charAt(pos - 1);
+            if( (c == ' ') || (c == '\n') ) {
+                pos--;
+            } else {
+                break;
+            }
+        }
+
+        if(pos == 0) {
+            return "";
+        }
+
+        CharSequence trimmedEnd = trimmed.subSequence(0, pos);
+        trimmed = trimmedEnd;
+        if((trimmed.length() > 0)
+                && (trimmed.charAt(trimmed.length() - 1) != '\n') ) {
+            trimmed = TextUtils.concat(trimmed, "\n"); // make sure last line is terminated
+        }
+
+        return trimmed;
     }
 
     /**

--- a/app/src/main/java/com/door43/translationstudio/core/ImportUsfm.java
+++ b/app/src/main/java/com/door43/translationstudio/core/ImportUsfm.java
@@ -1091,9 +1091,10 @@ public class ImportUsfm {
             if(strippedUsfmFrontTags.length() > 0) {
                 success = saveSection("front", "intro", strippedUsfmFrontTags);
                 successOverall = successOverall && success;
-                success = saveSection("front", "title", mBookName);
-                successOverall = successOverall && success;
             }
+            String chapter0 = "00"; // chapter "00" folder contains stuff that applies to the whole book, like title
+            success = saveSection(chapter0, "title", mBookName);
+            successOverall = successOverall && success;
         }
         return successOverall;
     }

--- a/app/src/main/java/com/door43/translationstudio/core/ImportUsfm.java
+++ b/app/src/main/java/com/door43/translationstudio/core/ImportUsfm.java
@@ -1089,10 +1089,9 @@ public class ImportUsfm {
         } else { // save stuff before first chapter
             String strippedUsfmFrontTags = removeKnownUsfmTags(cleanedString);
             if(strippedUsfmFrontTags.length() > 0) {
-                String chapter0 = "00"; // chapter "00" folder contains stuff that applies to the whole book, like title
                 success = saveSection("front", "intro", strippedUsfmFrontTags);
                 successOverall = successOverall && success;
-                success = saveSection(chapter0, "title", mBookName);
+                success = saveSection("front", "title", mBookName);
                 successOverall = successOverall && success;
             }
         }

--- a/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
+++ b/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
@@ -187,7 +187,14 @@ public class PdfPrinter extends PdfPageEventHelper {
 
         // book title
         ProjectTranslation projectTranslation = targetTranslation.getProjectTranslation();
-        Paragraph titleParagraph = (new Paragraph(projectTranslation.getTitle(), titleFont));
+        String title = projectTranslation.getTitle();
+        if(title.isEmpty()) {
+            Project project = App.getLibrary().index.getProject(targetTranslation.getTargetLanguageId(), targetTranslation.getProjectId(), true);
+            if( (project != null) && (project.name != null)) {
+                title = project.name;
+            }
+        }
+        Paragraph titleParagraph = (new Paragraph(title, titleFont));
         titleParagraph.setAlignment(Element.ALIGN_CENTER);
         preface.add(titleParagraph);
 


### PR DESCRIPTION
Fix #1827 Printing shows id tags if USFM import

Problem was that in USFM import, the USFM header tags were left in chapter front matter.  

Changes in this pull request:
- ImportUsfm: remove known USFM header tags from front matter.
- PdfPrinter: fix issue that no title is printed if title is not translated.  Now it will fall back to project name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1852)
<!-- Reviewable:end -->
