### PR TITLE
Fix #1667 - fix null text crash

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
         applicationId "com.translationstudio.androidapp"
         minSdkVersion 15
         targetSdkVersion 23
-        versionCode 154
+        versionCode 155
         versionName "11.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     } 

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -2243,7 +2243,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
                 renderingGroup.setSearchString(mSearchText, HIGHLIGHT_COLOR);
             }
         }
-        if(!text.trim().isEmpty()) {
+        if((text != null) && !text.trim().isEmpty()) {
             renderingGroup.init(text);
             CharSequence results = renderingGroup.start();
             item.hasMissingVerses = renderingGroup.isAddedMissingVerse();


### PR DESCRIPTION
Fix #1667 save verse marker null crash

Changes in this pull request:
- Add check for null text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1853)
<!-- Reviewable:end -->
