### PR TITLE
Fix #1822 QA fail - popup keyboard on search

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
@@ -87,6 +87,7 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
     private Timer mSearchTimer;
     private String mSearchString;
     private ProgressBar mSearchingSpinner;
+    private EditText mSearchEditText;
 
     private boolean mEnableGrids = false;
     private int mSeekbarMultiplier = 1; // allows for more granularity in setting position if cards are few
@@ -151,6 +152,7 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
         }
 
         mSearchingSpinner = (ProgressBar) findViewById(R.id.search_progress);
+        mSearchEditText = (EditText) findViewById(R.id.search_text);
         mReadButton = (ImageButton) findViewById(R.id.action_read);
         mChunkButton = (ImageButton) findViewById(R.id.action_chunk);
         mReviewButton = (ImageButton) findViewById(R.id.action_review);
@@ -533,10 +535,9 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
             searchPane.setVisibility(visibility);
             mSearchEnabled = show;
 
-            EditText edit = (EditText) searchPane.findViewById(R.id.search_text);
-            if(edit != null) {
+            if(mSearchEditText != null) {
                 if(mSearchTextWatcher != null) {
-                    edit.removeTextChangedListener(mSearchTextWatcher); // remove old listener
+                    mSearchEditText.removeTextChangedListener(mSearchTextWatcher); // remove old listener
                     mSearchTextWatcher = null;
                 }
 
@@ -565,7 +566,7 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
                         }
                     };
 
-                    edit.addTextChangedListener(mSearchTextWatcher);
+                    mSearchEditText.addTextChangedListener(mSearchTextWatcher);
                     setFocusOnTextSearchEdit();
                 } else {
                     filter(null); // clear search filter
@@ -573,7 +574,7 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
                 }
 
                 if(mSearchString != null) { // restore after rotate
-                    edit.setText(mSearchString);
+                    mSearchEditText.setText(mSearchString);
                     if(show) {
                         filter(mSearchString);
                     }
@@ -618,24 +619,24 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
      */
     @Deprecated
     private void setFocusOnTextSearchEdit() {
-        Handler hand = new Handler(Looper.getMainLooper());
-        hand.post(new Runnable() {
-            @Override
-            public void run() {
-                final EditText edit = (EditText) findViewById(R.id.search_text);
-                edit.setFocusableInTouchMode(true);
-                edit.requestFocus();
+        if(mSearchEditText != null) {
+            Handler hand = new Handler(Looper.getMainLooper());
+            hand.post(new Runnable() {
+                @Override
+                public void run() {
+                    mSearchEditText.setFocusableInTouchMode(true);
+                    mSearchEditText.requestFocus();
 
-                Handler hand = new Handler(Looper.getMainLooper());
-                hand.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        App.showKeyboard(TargetTranslationActivity.this, edit, true);
-                    }
-                });
-
-            }
-        });
+                    Handler hand = new Handler(Looper.getMainLooper());
+                    hand.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            App.showKeyboard(TargetTranslationActivity.this, mSearchEditText, true);
+                        }
+                    });
+                }
+            });
+        }
     }
 
     /**
@@ -707,10 +708,8 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
 
         LinearLayout searchPane = (LinearLayout) findViewById(R.id.search_pane);
         if(searchPane != null) {
-
-            EditText edit = (EditText) searchPane.findViewById(R.id.search_text);
-            if(edit != null) {
-                text = edit.getText().toString();
+            if(mSearchEditText != null) {
+                text = mSearchEditText.getText().toString();
             }
         }
         return text;
@@ -727,10 +726,8 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
 
         LinearLayout searchPane = (LinearLayout) findViewById(R.id.search_pane);
         if(searchPane != null) {
-
-            EditText edit = (EditText) searchPane.findViewById(R.id.search_text);
-            if(edit != null) {
-                edit.setText(text);
+            if(mSearchEditText != null) {
+                mSearchEditText.setText(text);
             }
         }
     }
@@ -794,7 +791,10 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
 
     public void closeKeyboard() {
         if (mFragment instanceof ViewModeFragment) {
-            ((ViewModeFragment) mFragment).closeKeyboard();
+            boolean enteringSearchText = mSearchEnabled && (mSearchEditText != null) && (mSearchEditText.hasFocus());
+            if(!enteringSearchText) { // we don't want to close keyboard if we are entering search text
+                ((ViewModeFragment) mFragment).closeKeyboard();
+            }
         }
     }
 


### PR DESCRIPTION

Fix #1822 popup keyboard on search

Changes in this pull request:
- TargetTranslationActivity: now saves handle to search edit text.  Fixed issue that notification of data change was closing keyboard as soon as search bar is brought up.  Now we don't automatically close the keyboard if the search bar is up and the search edit text has focus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1866)
<!-- Reviewable:end -->
