### PR TITLE
Fix #1637 QA fail - Cannot export to SD card

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/devtools/DeveloperToolsActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/devtools/DeveloperToolsActivity.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -25,6 +26,7 @@ import com.door43.translationstudio.App;
 import com.door43.translationstudio.R;
 import com.door43.translationstudio.ui.dialogs.ErrorLogDialog;
 import com.door43.translationstudio.ui.BaseActivity;
+import com.door43.util.SdUtils;
 import com.door43.util.StringUtilities;
 import com.door43.widget.ViewUtil;
 
@@ -154,7 +156,17 @@ public class DeveloperToolsActivity extends BaseActivity implements ManagedTask.
                 int killme = 1/0;
             }
         }));
-        mDeveloperTools.add(new ToolItem("Delete Library", "Deletes the entire library database so it can be rebuilt from scratch", R.drawable.ic_delete_black_24dp, new ToolItem.ToolAction() {
+
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            mDeveloperTools.add(new ToolItem("Reset SD Card Access", "", R.drawable.ic_warning_black_24dp, new ToolItem.ToolAction() {
+                @Override
+                public void run() {
+                    SdUtils.persistSdCardWriteAccess(Uri.parse("content://com.android.externalstorage.documents/tree/Fail_Me"), 0);
+                }
+            }));
+        }
+
+       mDeveloperTools.add(new ToolItem("Delete Library", "Deletes the entire library database so it can be rebuilt from scratch", R.drawable.ic_delete_black_24dp, new ToolItem.ToolAction() {
             @Override
             public void run() {
                 App.deleteLibrary();

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
@@ -445,7 +445,7 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
         mAccessFile = filename;
         new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
                 .setTitle(R.string.enable_sd_card_access_title)
-                .setMessage(Html.fromHtml(getString(R.string.enable_sd_card_access)))
+                .setMessage(getString(R.string.enable_sd_card_access))
                 .setPositiveButton(R.string.confirm, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {

--- a/app/src/main/java/com/door43/util/SdUtils.java
+++ b/app/src/main/java/com/door43/util/SdUtils.java
@@ -221,8 +221,13 @@ public class SdUtils {
             Logger.i(SdUtils.class.getName(), "Apply permissions to URI '" + sdUri.toString() + "' flags: " + flags);
             int takeFlags = flags
                     & (Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-            App.context().grantUriPermission(App.context().getPackageName(), sdUri, takeFlags); //TODO 12/22/2015 need to find way to remove this warning
-            App.context().getContentResolver().takePersistableUriPermission(sdUri, takeFlags);
+            try {
+                App.context().grantUriPermission(App.context().getPackageName(), sdUri, takeFlags); //TODO 12/22/2015 need to find way to remove this warning
+                App.context().getContentResolver().takePersistableUriPermission(sdUri, takeFlags);
+            } catch (Exception e) {
+                Logger.e(SdUtils.class.getName(), "Failed to Apply Permissions",e);
+                return false;
+            }
             return true;
         }
         return false;
@@ -689,11 +694,14 @@ public class SdUtils {
 
             DocumentFile[] files = document.listFiles();
             for(DocumentFile file: files) {
-                String ext = FileUtilities.getExtension(file.getName());
-                if(ext != null) {
-                    if (ext.toLowerCase().equals(extension)) {
-                        if ((file != null) && file.canRead()) {
-                            return path;
+                String fileName = file.getName();
+                if(fileName != null) { // will get null if no permissions
+                    String ext = FileUtilities.getExtension(fileName);
+                    if (ext != null) {
+                        if (ext.toLowerCase().equals(extension)) {
+                            if ((file != null) && file.canRead()) {
+                                return path;
+                            }
                         }
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -644,14 +644,15 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
     <string name="enable_sd_card_access_title">Enable SD Card Access</string>
     <string name="enable_sd_card_access">
 <![CDATA[
-<p>Do you want to enable SD card access?  If so then:</p>
-<ul>
-  <li>Click Confirm and wait for access dialog to appear</li>
-  <li>If SD Card is not shown on left, click on menu (three vertical dots in upper right corner)</li>
-  <li>Click on SD Card on left</li>
-  <li>Click on \'Select "SD Card"\' at bottom</li>
-</ul>
-<p>If you press SKIP, then import/backup will be with internal memory.</p>
+Do you want to enable SD card access?  If so then:
+\n
+\n\u00A0\u00A0* Click Confirm and wait for access dialog to appear
+\n\u00A0\u00A0* If SD Card is not shown on left, click on menu
+\n\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0(three vertical dots in upper right corner)
+\n\u00A0\u00A0* Click on SD Card on left
+\n\u00A0\u00A0* Click on \'Select "SD Card"\' at bottom
+\n
+\nIf you press SKIP, then import/backup will be with internal memory.
 ]]>
     </string>
     <string name="access_title">Access Attempt</string>


### PR DESCRIPTION
Fix #1637 QA fail - Cannot export to SD card
Also fixes formatting issue in #1638

Changes in this pull request:
- SdUtils - added capture of exception if sd card access permissions are not granted. Added capture of exception if we don't have permission in searching for files.
- DeveloperToolsActivity - added option to reset SD card access.
- Fixed formatting of SD card access prompt (new alert dialog does not work with spannable strings from html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1868)
<!-- Reviewable:end -->
