### PR TITLE
Fix #1777 fix upload verbiage to be more consistent with desktop

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
@@ -837,7 +837,7 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
         // open bug report dialog
         FeedbackDialog feedbackDialog = new FeedbackDialog();
         Bundle args = new Bundle();
-        String message = "Failed to backup the translation of " +
+        String message = "Failed to upload the translation of " +
                 project.name + " into " +
                 targetTranslation.getTargetLanguageName()
                 + ".\ntargetTranslation: " + targetTranslation.getId() +

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -854,7 +854,7 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
     <string name="search_source">Search Source:</string>
     <string name="search_translation">Search Translation:</string>
     <string name="tip_export_to_usfm">Creates a .usfm file of your project or a zip file of the chapters in your project</string>
-    <string name="export_to_pdf">Export to PDF</string>
+    <string name="export_to_pdf">Export to PDF File</string>
     <string name="tip_export_to_pdf">Sends a .pdf file of your project</string>
     <string name="title_upload_export">Upload/Export Options</string>
     <string name="menu_upload_export">Upload/Export</string>
@@ -870,7 +870,7 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
     <string name="export_usfm_by_chapter">Do you want the USFM output separated into chapters or do you want the whole book as a single file?</string>
     <string name="label_separate">Separate</string>
     <string name="label_whole">Whole</string>
-    <string name="export_to_usfm">Export USFM to SD Card</string>
+    <string name="export_to_usfm">Export to USFM file</string>
     <string name="export_failed">Export failed!</string>
     <string name="export_success">Export successful!\n\nExported file is at:\n<xliff:g example="/sd_card/downloads" id="file_path">%1$s</xliff:g></string>
     <string name="update_source_language">Do you want to update \'<xliff:g example="Pig Latin" id="language">%1$s</xliff:g>\' from Online (requires internet)?</string>


### PR DESCRIPTION
Fix #1777 fix upload verbiage to be more consistent with desktop

Also fixes #1850 backup verbiage.

Changes in this pull request:
- Upload dialog - changed verbiage to be more consistent with desktop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1870)
<!-- Reviewable:end -->
