### PR TITLE
Fix #1637 QA Fail - cannot export to SD card

### DIFF
--- a/app/src/androidTest/java/com/door43/translationstudio/ImportExportTest.java
+++ b/app/src/androidTest/java/com/door43/translationstudio/ImportExportTest.java
@@ -40,8 +40,8 @@ public class ImportExportTest extends InstrumentationTestCase {
 //        file.getParentFile().mkdirs();
 //        Util.copyStreamToCache(this.context, this.context.getAssets().open("exports/3.0.1_uw-obs-aa.tstudio"), file);
 //        Translator.ImportResults results = this.translator.importArchive(file);
-//        assertNotNull(results.filePath);
-//        assertEquals(results.filePath, targetTranslationId);
+//        assertNotNull(results.importedSlug);
+//        assertEquals(results.importedSlug, targetTranslationId);
 //        TargetTranslation targetTranslation = this.translator.getTargetTranslation(targetTranslationId);
 //        assertNotNull(targetTranslation);
 //        assertTrue(targetTranslation.getChapterTranslations().length > 0);

--- a/app/src/androidTest/java/com/door43/translationstudio/ImportExportTest.java
+++ b/app/src/androidTest/java/com/door43/translationstudio/ImportExportTest.java
@@ -40,8 +40,8 @@ public class ImportExportTest extends InstrumentationTestCase {
 //        file.getParentFile().mkdirs();
 //        Util.copyStreamToCache(this.context, this.context.getAssets().open("exports/3.0.1_uw-obs-aa.tstudio"), file);
 //        Translator.ImportResults results = this.translator.importArchive(file);
-//        assertNotNull(results.importedSlug);
-//        assertEquals(results.importedSlug, targetTranslationId);
+//        assertNotNull(results.filePath);
+//        assertEquals(results.filePath, targetTranslationId);
 //        TargetTranslation targetTranslation = this.translator.getTargetTranslation(targetTranslationId);
 //        assertNotNull(targetTranslation);
 //        assertTrue(targetTranslation.getChapterTranslations().length > 0);

--- a/app/src/main/java/com/door43/translationstudio/core/Translator.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Translator.java
@@ -17,6 +17,7 @@ import com.door43.util.Zip;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -297,9 +298,10 @@ public class Translator {
      */
     public void exportArchive(TargetTranslation targetTranslation, File outputFile) throws Exception {
 
-        FileOutputStream out = null;
+        BufferedOutputStream out = null;
         try {
-            out = new FileOutputStream(outputFile);
+            FileOutputStream fout = new FileOutputStream(outputFile);
+            out = new BufferedOutputStream(fout);
             exportArchive(targetTranslation, out, outputFile.toString());
         } catch (Exception e) {
             throw e;

--- a/app/src/main/java/com/door43/translationstudio/tasks/ExportToSDCardTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/ExportToSDCardTask.java
@@ -1,5 +1,6 @@
 package com.door43.translationstudio.tasks;
 
+import android.os.Process;
 import android.support.v4.provider.DocumentFile;
 
 import com.door43.translationstudio.App;
@@ -22,12 +23,11 @@ public class ExportToSDCardTask extends ManagedTask {
     public static final String TASK_ID = "export_to_sd_card_task";
     public static final String TAG = ExportToSDCardTask.class.getSimpleName();
     final private String filename;
-    final private String title;
     final private TargetTranslation targetTranslation;
 
-    public ExportToSDCardTask(String filename, TargetTranslation targetTranslation, String title) {
+    public ExportToSDCardTask(String filename, TargetTranslation targetTranslation) {
+        setThreadPriority(Process.THREAD_PRIORITY_DEFAULT);
         this.filename = filename;
-        this.title = title;
         this.targetTranslation = targetTranslation;
     }
 
@@ -39,7 +39,7 @@ public class ExportToSDCardTask extends ManagedTask {
         DocumentFile sdCardFile = null;
         OutputStream out = null;
         boolean success = false;
-        publishProgress(-1, title);
+        publishProgress(-1, "");
 
         try {
             if(SdUtils.isSdCardPresentLollipop()) {
@@ -93,5 +93,13 @@ public class ExportToSDCardTask extends ManagedTask {
             this.filePath = filePath;
             this.success = success;
         }
+    }
+
+    /**
+     * Returns the maximum progress threshold
+     * @return
+     */
+    public int maxProgress() {
+        return 1;
     }
 }

--- a/app/src/main/java/com/door43/translationstudio/tasks/ExportToSDCardTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/ExportToSDCardTask.java
@@ -1,0 +1,97 @@
+package com.door43.translationstudio.tasks;
+
+import android.support.v4.provider.DocumentFile;
+
+import com.door43.translationstudio.App;
+import com.door43.translationstudio.core.TargetTranslation;
+import com.door43.util.FileUtilities;
+import com.door43.util.SdUtils;
+
+import org.unfoldingword.tools.logger.Logger;
+import org.unfoldingword.tools.taskmanager.ManagedTask;
+
+import java.io.File;
+import java.io.OutputStream;
+
+/**
+ * Created by blm on 2/22/17.
+ */
+
+public class ExportToSDCardTask extends ManagedTask {
+
+    public static final String TASK_ID = "export_to_sd_card_task";
+    public static final String TAG = ExportToSDCardTask.class.getSimpleName();
+    final private String filename;
+    final private String title;
+    final private TargetTranslation targetTranslation;
+
+    public ExportToSDCardTask(String filename, TargetTranslation targetTranslation, String title) {
+        this.filename = filename;
+        this.title = title;
+        this.targetTranslation = targetTranslation;
+    }
+
+    @Override
+    public void start() {
+        boolean canWriteToSdCardBackupLollipop = false;
+        DocumentFile baseFolder = null;
+        String filePath = null;
+        DocumentFile sdCardFile = null;
+        OutputStream out = null;
+        boolean success = false;
+        publishProgress(-1, title);
+
+        try {
+            if(SdUtils.isSdCardPresentLollipop()) {
+                baseFolder = SdUtils.sdCardMkdirs(SdUtils.DOWNLOAD_TRANSLATION_STUDIO_FOLDER);
+                canWriteToSdCardBackupLollipop = baseFolder != null;
+            }
+
+            if (canWriteToSdCardBackupLollipop) { // default to writing to SD card if available
+                filePath = SdUtils.getPathString(baseFolder);
+                if (baseFolder.canWrite()) {
+                    sdCardFile = SdUtils.documentFileCreate(baseFolder, filename);
+                    filePath = SdUtils.getPathString(sdCardFile);
+                    out = SdUtils.createOutputStream(sdCardFile);
+                    App.getTranslator().exportArchive(targetTranslation, out, filename);
+                    success = true;
+                }
+            } else {
+                File exportFile = new File(App.getPublicDownloadsDirectory(), filename);
+                filePath = exportFile.toString();
+                App.getTranslator().exportArchive(targetTranslation, exportFile);
+                success = exportFile.exists();
+            }
+        } catch (Exception e) {
+            success = false;
+            Logger.e(TAG, "Failed to export the target translation " + targetTranslation.getId(), e);
+            if(sdCardFile != null) {
+                try {
+                    if(null != out) {
+                        FileUtilities.closeQuietly(out);
+                    }
+                    sdCardFile.delete();
+                } catch(Exception e2) {
+                    Logger.e(TAG, "Cleanup failed", e2);
+                }
+            }
+        }
+
+        setResult(new ExportResults(filePath, success));
+    }
+
+    /**
+     * returns the import results which includes:
+     *   the human readable filePath
+     *   the success flag
+     */
+    public class ExportResults {
+        public final String filePath;
+        public final boolean success;
+
+        ExportResults(String filePath, boolean success) {
+            this.filePath = filePath;
+            this.success = success;
+        }
+    }
+}

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
@@ -488,7 +488,7 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
                 if (baseFolder.canWrite()) {
                     sdCardFile = SdUtils.documentFileCreate(baseFolder, fileName);
                     filePath = SdUtils.getPathString(sdCardFile);
-                    out = App.context().getContentResolver().openOutputStream(sdCardFile.getUri());
+                    out = SdUtils.createOutputStream(sdCardFile);
                     App.getTranslator().exportArchive(targetTranslation, out, fileName);
                     success = true;
                 }
@@ -501,6 +501,7 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
             }
         } catch (Exception e) {
             success = false;
+            Logger.e(TAG, "Failed to export the target translation " + targetTranslation.getId(), e);
             if(sdCardFile != null) {
                 try {
                     if(null != out) {
@@ -508,11 +509,12 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
                     }
                     sdCardFile.delete();
                 } catch(Exception e2) {
+                    Logger.e(TAG, "Cleanup failed", e2);
                 }
             }
-            Logger.e(TAG, "Failed to export the target translation " + targetTranslation.getId(), e);
         }
 
+        Logger.i(TAG, "Project export success = " + success);
         if (success) {
             showBackupResults(R.string.backup_success, filePath);
         } else {

--- a/app/src/main/java/com/door43/util/SdUtils.java
+++ b/app/src/main/java/com/door43/util/SdUtils.java
@@ -96,7 +96,12 @@ public class SdUtils {
             pos = uriStr.lastIndexOf(CONTENT_DIVIDER);
             if(pos >= 0) {
                 String subPath =  uriStr.substring(pos + CONTENT_DIVIDER.length());
-                String showPath = "SD_CARD/" + Uri.decode(subPath);
+
+                String actualPath = findSdCardFolder();
+                if(actualPath == null) {
+                    actualPath = "SD_CARD"; // use place holder text if we failed to find true path
+                }
+                String showPath = actualPath + "/" + Uri.decode(subPath);
                 Logger.i(SdUtils.class.getName(), "converting SD card path from '" + dir + "' to '" + showPath + "'");
                 return showPath;
             }

--- a/app/src/main/java/com/door43/util/SdUtils.java
+++ b/app/src/main/java/com/door43/util/SdUtils.java
@@ -14,6 +14,7 @@ import org.unfoldingword.tools.logger.Logger;
 import com.door43.translationstudio.App;
 import com.door43.translationstudio.ui.SettingsActivity;
 
+import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -481,7 +482,7 @@ public class SdUtils {
         OutputStream fout = null;
 
         try {
-            fout = App.context().getContentResolver().openOutputStream(document.getUri());
+            fout = createOutputStream(document);
             fout.write(data.getBytes());
             fout.close();
         } catch (Exception e) {
@@ -525,7 +526,8 @@ public class SdUtils {
      * @return
      */
     public static OutputStream createOutputStream(DocumentFile outputFile) throws FileNotFoundException {
-        return App.context().getContentResolver().openOutputStream(outputFile.getUri());
+        OutputStream out = App.context().getContentResolver().openOutputStream(outputFile.getUri());
+        return new BufferedOutputStream(out); // add buffering to improve performance on writing to SD card
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -958,4 +958,5 @@ Do you want to enable SD card access?  If so then:
     <string name="merge_projects_label">Merge Projects</string>
     <string name="overwrite_projects_label">Overwrite Project</string>
     <string name="import_merge_conflict_choices">Merge conflict on Import - Click OK to resolve merge or Click CANCEL to keep project unchanged</string>
+    <string name="exporting_wait">Exporting, please wait...</string>
 </resources>


### PR DESCRIPTION
Fix #1637 QA Fail - cannot export to SD card

Changes in this pull request:
- Translator - added buffering to export Archive. 
- SdUtils - added buffering to writing to SD card. Tweaked getPathString to show actual SD card path if known.
- BackupDialog - moved SD card output into ExportToSDCardTask so we can have progress dialog.
- BackupDialog - changing the progress title between upload and export operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1887)
<!-- Reviewable:end -->
