### PR TITLE
Fix #1765 remove custom formatting on project files in File Chooser

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/filechooser/FileChooserAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/filechooser/FileChooserAdapter.java
@@ -41,30 +41,9 @@ public class FileChooserAdapter extends BaseAdapter {
     }
 
     public void loadFiles(Context context, List<DocumentFileItem> files) {
-        final Door43Client library = App.getLibrary();
         mFiles = files;
-        new ThreadableUI(context) {
-
-            @Override
-            public void onStop() {
-
-            }
-
-            @Override
-            public void run() {
-                for(DocumentFileItem item:mFiles) {
-                    if(item.isTranslationArchive()) {
-                        item.inspect(App.getDeviceLanguageCode(), library);
-                    }
-                }
-            }
-
-            @Override
-            public void onPostExecute() {
-                sortFiles(mFiles);
-                notifyDataSetChanged();
-            }
-        }.start();
+        sortFiles(mFiles);
+        notifyDataSetChanged();
     }
 
     @Override


### PR DESCRIPTION
Fix #1765 remove custom formatting on project files in File Chooser

Changes in this pull request:
- remove custom formatting on project files in File Chooser

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1891)
<!-- Reviewable:end -->
