### PR TITLE
Fix #1824 disable selection of unsupported resources

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/core/TargetTranslation.java
+++ b/app/src/main/java/com/door43/translationstudio/core/TargetTranslation.java
@@ -421,6 +421,20 @@ public class TargetTranslation {
     }
 
     /**
+     * Returns the id of the resource type of the target translation
+     * @param targetTranslationId the target translation id
+     * @return
+     */
+    public static String getResourceTypeFromId(String targetTranslationId) throws StringIndexOutOfBoundsException {
+        String[] complexId = targetTranslationId.split("_");
+        if(complexId.length >= 3) {
+            return complexId[2];
+        } else {
+            throw new StringIndexOutOfBoundsException("malformed target translation id " + targetTranslationId);
+        }
+    }
+
+    /**
      * Generates the file to the directory where the target translation is located
      *
      * @param targetTranslationId the language to which the project is being translated

--- a/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
@@ -121,6 +121,7 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
 
         ListView list = (ListView) v.findViewById(R.id.list);
         adapter = new TranslationRepositoryAdapter();
+        adapter.setTextOnlyResources(true); // only allow importing of text resources
         list.setAdapter(adapter);
         list.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override

--- a/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
@@ -125,11 +125,13 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
         list.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                Repository repo = adapter.getItem(position);
-                String repoName = repo.getFullName().replace("/", "-");
-                cloneDestDir = new File(App.context().getCacheDir(), repoName + System.currentTimeMillis() + "/");
-                mCloneHtmlUrl = repo.getHtmlUrl();
-                cloneRepository(false);
+                if(adapter.isSupported(position)) {
+                    Repository repo = adapter.getItem(position);
+                    String repoName = repo.getFullName().replace("/", "-");
+                    cloneDestDir = new File(App.context().getCacheDir(), repoName + System.currentTimeMillis() + "/");
+                    mCloneHtmlUrl = repo.getHtmlUrl();
+                    cloneRepository(false);
+                }
             }
         });
 

--- a/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
@@ -126,12 +126,25 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
         list.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                if(adapter.isSupported(position)) {
-                    Repository repo = adapter.getItem(position);
-                    String repoName = repo.getFullName().replace("/", "-");
-                    cloneDestDir = new File(App.context().getCacheDir(), repoName + System.currentTimeMillis() + "/");
-                    mCloneHtmlUrl = repo.getHtmlUrl();
-                    cloneRepository(false);
+                if(adapter != null) {
+                    final int final_pos = position;
+                    if (adapter.isSupported(position)) {
+                        doImportProject(position);
+                    } else {
+                        String projectName = adapter.getProjectName(position);
+                        String message = getActivity().getString(R.string.import_warning, projectName);
+                        new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
+                                .setTitle(R.string.import_from_door43)
+                                .setMessage(message)
+                                .setPositiveButton(R.string.label_ok, new DialogInterface.OnClickListener() {
+                                    @Override
+                                    public void onClick(DialogInterface dialogInterface, int i) {
+                                        doImportProject(final_pos);
+                                    }
+                                })
+                                .setNegativeButton(R.string.title_cancel, null)
+                                .show();
+                    }
                 }
             }
         });
@@ -173,6 +186,18 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
 
         restoreDialogs();
         return v;
+    }
+
+    /**
+     * do import of project at position
+     * @param position
+     */
+    private void doImportProject(int position) {
+        Repository repo = adapter.getItem(position);
+        String repoName = repo.getFullName().replace("/", "-");
+        cloneDestDir = new File(App.context().getCacheDir(), repoName + System.currentTimeMillis() + "/");
+        mCloneHtmlUrl = repo.getHtmlUrl();
+        cloneRepository(false);
     }
 
     /**

--- a/app/src/main/java/com/door43/translationstudio/ui/home/TranslationRepositoryAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/TranslationRepositoryAdapter.java
@@ -1,5 +1,7 @@
 package com.door43.translationstudio.ui.home;
 
+import android.content.Context;
+import android.graphics.Typeface;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -47,6 +49,14 @@ public class TranslationRepositoryAdapter extends BaseAdapter {
         return this.repositories.get(position);
     }
 
+    public boolean isSupported(int position) {
+        Item item = loadItem(position);
+        if(item != null) {
+            return item.isSupported();
+        }
+        return false;
+    }
+
     @Override
     public long getItemId(int position) {
         return 0;
@@ -64,7 +74,7 @@ public class TranslationRepositoryAdapter extends BaseAdapter {
             holder = (ViewHolder) v.getTag();
         }
 
-        holder.setItem(loadItem(position));
+        holder.setItem(loadItem(position), parent.getContext());
 
         return v;
     }
@@ -97,11 +107,27 @@ public class TranslationRepositoryAdapter extends BaseAdapter {
             String[] repoName = repo.getFullName().split("/");
             String projectName = "";
             String languageName = "";
+            int notSupportedID = 0;
             if (repoName.length > 0) {
                 String targetTranslationSlug = repoName[repoName.length - 1];
                 try {
                     String projectSlug = TargetTranslation.getProjectSlugFromId(targetTranslationSlug);
                     String targetLanguageSlug = TargetTranslation.getTargetLanguageSlugFromId(targetTranslationSlug);
+                    String resourceTypeSlug = TargetTranslation.getResourceTypeFromId(targetTranslationSlug);
+
+                    if(!"text".equals(resourceTypeSlug)) { // we only support text
+                        if("tw".equals(resourceTypeSlug)) {
+                            notSupportedID = R.string.translation_words;
+                        } else if("tn".equals(resourceTypeSlug)) {
+                            notSupportedID = R.string.label_translation_notes;
+                        } else if("tq".equals(resourceTypeSlug)) {
+                            notSupportedID = R.string.translation_questions;
+                        } else if("ta".equals(resourceTypeSlug)) {
+                            notSupportedID = R.string.translation_academy;
+                        } else {
+                            notSupportedID = R.string.unsupported;
+                        }
+                    }
 
                     Project p = library.index.getProject(App.getDeviceLanguageCode(), projectSlug, true);
                     if (p != null) {
@@ -118,9 +144,10 @@ public class TranslationRepositoryAdapter extends BaseAdapter {
                 } catch (StringIndexOutOfBoundsException e) {
                     e.printStackTrace();
                     projectName = targetTranslationSlug;
+                    notSupportedID = R.string.unsupported;
                 }
             }
-            items[position] = new Item(languageName, projectName, repo.getHtmlUrl(), repo.getIsPrivate());
+            items[position] = new Item(languageName, projectName, repo.getHtmlUrl(), repo.getIsPrivate(), notSupportedID);
         }
         return items[position];
     }
@@ -143,14 +170,23 @@ public class TranslationRepositoryAdapter extends BaseAdapter {
          * Loads the item into the view
          * @param item the item to be displayed in this view
          */
-        public void setItem(Item item) {
+        public void setItem(Item item, Context context) {
             targetLanguageName.setText(item.languageName);
-            projectName.setText(item.projectName);
             if(item.isPrivate) {
                 this.privacy.setImageResource(R.drawable.ic_lock_black_18dp);
             } else {
                 this.privacy.setImageResource(R.drawable.ic_lock_open_black_18dp);
             }
+            String projectNameStr = item.projectName;
+            if(item.isSupported()) {
+                projectName.setTypeface(null, Typeface.BOLD);
+                projectName.setTextColor(context.getResources().getColor(R.color.dark_primary_text));
+            } else {
+                projectName.setTypeface(null, Typeface.NORMAL);
+                projectName.setTextColor(context.getResources().getColor(R.color.dark_disabled_text));
+                projectNameStr += " - " + context.getString(item.notSupportedId);
+            }
+            projectName.setText(projectNameStr);
             repoUrl.setText(item.url);
         }
     }
@@ -163,12 +199,18 @@ public class TranslationRepositoryAdapter extends BaseAdapter {
         private final String languageName;
         private final String url;
         private final boolean isPrivate;
+        private final int notSupportedId; // a project type that ts-android cannot import will have a non-zero resource ID here
 
-        public Item(String languageName, String projectName, String url, boolean isPrivate) {
+        public Item(String languageName, String projectName, String url, boolean isPrivate, int notSupportedId) {
             this.projectName = projectName;
             this.languageName = languageName;
             this.url = url;
             this.isPrivate = isPrivate;
+            this.notSupportedId = notSupportedId;
+        }
+
+        public boolean isSupported() {
+            return (notSupportedId == 0);
         }
     }
 }

--- a/app/src/main/java/com/door43/translationstudio/ui/home/TranslationRepositoryAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/TranslationRepositoryAdapter.java
@@ -29,6 +29,7 @@ public class TranslationRepositoryAdapter extends BaseAdapter {
     private List<Repository> repositories = new ArrayList<>();
     private Item[] items = new Item[0];
     private final Door43Client library;
+    private boolean textOnlyResources = false; // if set then anything not a text resource is disabled
 
     public TranslationRepositoryAdapter() {
         this.library = App.getLibrary();
@@ -94,6 +95,11 @@ public class TranslationRepositoryAdapter extends BaseAdapter {
         }
     }
 
+
+    public void setTextOnlyResources(boolean textOnlyResources) {
+        this.textOnlyResources = textOnlyResources;
+    }
+
     /**
      * Loads the data in an item
      * @param position the position of the item in the list
@@ -113,19 +119,21 @@ public class TranslationRepositoryAdapter extends BaseAdapter {
                 try {
                     String projectSlug = TargetTranslation.getProjectSlugFromId(targetTranslationSlug);
                     String targetLanguageSlug = TargetTranslation.getTargetLanguageSlugFromId(targetTranslationSlug);
-                    String resourceTypeSlug = TargetTranslation.getResourceTypeFromId(targetTranslationSlug);
 
-                    if(!"text".equals(resourceTypeSlug)) { // we only support text
-                        if("tw".equals(resourceTypeSlug)) {
-                            notSupportedID = R.string.translation_words;
-                        } else if("tn".equals(resourceTypeSlug)) {
-                            notSupportedID = R.string.label_translation_notes;
-                        } else if("tq".equals(resourceTypeSlug)) {
-                            notSupportedID = R.string.translation_questions;
-                        } else if("ta".equals(resourceTypeSlug)) {
-                            notSupportedID = R.string.translation_academy;
-                        } else {
-                            notSupportedID = R.string.unsupported;
+                    if(textOnlyResources) {
+                        String resourceTypeSlug = TargetTranslation.getResourceTypeFromId(targetTranslationSlug);
+                        if (!"text".equals(resourceTypeSlug)) { // we only support text
+                            if ("tw".equals(resourceTypeSlug)) {
+                                notSupportedID = R.string.translation_words;
+                            } else if ("tn".equals(resourceTypeSlug)) {
+                                notSupportedID = R.string.label_translation_notes;
+                            } else if ("tq".equals(resourceTypeSlug)) {
+                                notSupportedID = R.string.translation_questions;
+                            } else if ("ta".equals(resourceTypeSlug)) {
+                                notSupportedID = R.string.translation_academy;
+                            } else {
+                                notSupportedID = R.string.unsupported;
+                            }
                         }
                     }
 

--- a/app/src/main/java/com/door43/translationstudio/ui/home/TranslationRepositoryAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/TranslationRepositoryAdapter.java
@@ -50,12 +50,30 @@ public class TranslationRepositoryAdapter extends BaseAdapter {
         return this.repositories.get(position);
     }
 
+    /**
+     * determine if item at position is supported project type
+     * @param position
+     * @return
+     */
     public boolean isSupported(int position) {
         Item item = loadItem(position);
         if(item != null) {
             return item.isSupported();
         }
         return false;
+    }
+
+    /**
+     * get project name for item at position
+     * @param position
+     * @return
+     */
+    public String getProjectName(int position) {
+        Item item = loadItem(position);
+        if(item != null) {
+            return item.projectName;
+        }
+        return "";
     }
 
     @Override

--- a/app/src/main/java/com/door43/translationstudio/ui/home/TranslationRepositoryAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/TranslationRepositoryAdapter.java
@@ -71,7 +71,11 @@ public class TranslationRepositoryAdapter extends BaseAdapter {
     public String getProjectName(int position) {
         Item item = loadItem(position);
         if(item != null) {
-            return item.projectName;
+            String projectName = item.projectName;
+            if(!projectName.equalsIgnoreCase(item.targetTranslationSlug)) {
+                projectName += " (" + item.targetTranslationSlug + ")"; // if not same as project name, add project id
+            }
+            return projectName;
         }
         return "";
     }
@@ -132,8 +136,9 @@ public class TranslationRepositoryAdapter extends BaseAdapter {
             String projectName = "";
             String languageName = "";
             int notSupportedID = 0;
+            String targetTranslationSlug = "";
             if (repoName.length > 0) {
-                String targetTranslationSlug = repoName[repoName.length - 1];
+                targetTranslationSlug = repoName[repoName.length - 1];
                 try {
                     String projectSlug = TargetTranslation.getProjectSlugFromId(targetTranslationSlug);
                     String targetLanguageSlug = TargetTranslation.getTargetLanguageSlugFromId(targetTranslationSlug);
@@ -173,7 +178,7 @@ public class TranslationRepositoryAdapter extends BaseAdapter {
                     notSupportedID = R.string.unsupported;
                 }
             }
-            items[position] = new Item(languageName, projectName, repo.getHtmlUrl(), repo.getIsPrivate(), notSupportedID);
+            items[position] = new Item(languageName, projectName, targetTranslationSlug, repo.getHtmlUrl(), repo.getIsPrivate(), notSupportedID);
         }
         return items[position];
     }
@@ -222,14 +227,16 @@ public class TranslationRepositoryAdapter extends BaseAdapter {
      */
     private class Item {
         private final String projectName;
+        private final String targetTranslationSlug;
         private final String languageName;
         private final String url;
         private final boolean isPrivate;
         private final int notSupportedId; // a project type that ts-android cannot import will have a non-zero resource ID here
 
-        public Item(String languageName, String projectName, String url, boolean isPrivate, int notSupportedId) {
+        public Item(String languageName, String projectName, String targetTranslationSlug, String url, boolean isPrivate, int notSupportedId) {
             this.projectName = projectName;
             this.languageName = languageName;
+            this.targetTranslationSlug = targetTranslationSlug;
             this.url = url;
             this.isPrivate = isPrivate;
             this.notSupportedId = notSupportedId;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -731,7 +731,7 @@ Do you want to enable SD card access?  If so then:
     <string name="still_possible_to_register_door43">You can still create or login to a Door43 account later</string>
     <string name="title_connect_door43">Connect To Door43</string>
     <string name="gogs_public_key_name">ts-android</string>
-    <string name="restore_failed">The translation could not be restored</string>
+    <string name="restore_failed">The translation could not be imported</string>
     <string name="import_from_door43">Import from Door43</string>
     <string name="restore_from_door43">Restore from Door43</string>
     <string name="title_chunk_conflicts">Chunk Conflicts</string>
@@ -962,4 +962,5 @@ Do you want to enable SD card access?  If so then:
     <string name="translation_questions">Questions</string>
     <string name="translation_academy">Translation Academy</string>
     <string name="unsupported">Unsupported</string>
+    <string name="import_warning">The project \'<xliff:g example="MysteryProject" id="project_name">%1$s</xliff:g>\' may not be supported in this app.  Do you want to try to download it anyway?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -962,5 +962,5 @@ Do you want to enable SD card access?  If so then:
     <string name="translation_questions">Questions</string>
     <string name="translation_academy">Translation Academy</string>
     <string name="unsupported">Unsupported</string>
-    <string name="import_warning">The project \'<xliff:g example="MysteryProject" id="project_name">%1$s</xliff:g>\' may not be supported in this app.  Do you want to try to download it anyway?</string>
+    <string name="import_warning">The project \'<xliff:g example="MysteryProject" id="project_name">%1$s</xliff:g>\' may not be supported in this app.  We only support importing regular translation projects - not helps or Translation Academy.  Do you want to try to import it anyway?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -959,4 +959,7 @@ Do you want to enable SD card access?  If so then:
     <string name="overwrite_projects_label">Overwrite Project</string>
     <string name="import_merge_conflict_choices">Merge conflict on Import - Click OK to resolve merge or Click CANCEL to keep project unchanged</string>
     <string name="project_output_filename_title_prompt">Enter Project output file name:</string>
+    <string name="translation_questions">Questions</string>
+    <string name="translation_academy">Translation Academy</string>
+    <string name="unsupported">Unsupported</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -962,5 +962,5 @@ Do you want to enable SD card access?  If so then:
     <string name="translation_questions">Questions</string>
     <string name="translation_academy">Translation Academy</string>
     <string name="unsupported">Unsupported</string>
-    <string name="import_warning">The project \'<xliff:g example="MysteryProject" id="project_name">%1$s</xliff:g>\' may not be supported in this app.  We only support importing regular translation projects - not helps or Translation Academy.  Do you want to try to import it anyway?</string>
+    <string name="import_warning">The project \'<xliff:g example="MysteryProject" id="project_name">%1$s</xliff:g>\' may not be supported in this app.  Currently, translationStudio only supports Scripture and Open Bible Stories projects. If this is not one of those types of projects it will not be imported into translationStudio.\n\nDo you want to try to import it anyway?</string>
 </resources>


### PR DESCRIPTION
Fix #1824 disable selection of unsupported resources

Changes in this pull request:
- TargetTranslation - added method to get resource type from id
- ImportFromDoor43Dialog - added check to make sure item is supported before opening.
- TranslationRepositoryAdapter - added checking to see if resource is supported, and grey out 
- TranslationRepositoryAdapter - made filtering for supported text translations optional.
- Added warning to user that project may not be supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1905)
<!-- Reviewable:end -->
