### PR TITLE
Fix #1809 target card corruption on done

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -827,11 +827,13 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewModeAdapter.ViewHol
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 if (isChecked) {
-                    // make sure to capture verse marker changes changes before dialog is displayed
-                    Editable changes = holder.mTargetEditableBody.getText();
-                    item.renderedTargetText = changes;
-                    String newBody = Translator.compileTranslation(changes);
-                    item.targetText = newBody;
+                    if(item.isEditing) {
+                        // make sure to capture verse marker changes changes before dialog is displayed
+                        Editable changes = holder.mTargetEditableBody.getText();
+                        item.renderedTargetText = changes;
+                        String newBody = Translator.compileTranslation(changes);
+                        item.targetText = newBody;
+                    }
 
                     new AlertDialog.Builder(mContext,R.style.AppTheme_Dialog)
                             .setTitle(R.string.chunk_checklist_title)


### PR DESCRIPTION
Fix #1809 target card corruption on done

Changes in this pull request:
- Fix issue that when user selects done on a chunk, but is not in edit mode; then recycled junk is read in from mTargetEditableBody.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1907)
<!-- Reviewable:end -->
