### PR TITLE
Fix #1824 QA fail fix verbiage on unsupported import dialog

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
@@ -136,7 +136,7 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
                         new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
                                 .setTitle(R.string.import_from_door43)
                                 .setMessage(message)
-                                .setPositiveButton(R.string.label_ok, new DialogInterface.OnClickListener() {
+                                .setPositiveButton(R.string.label_import, new DialogInterface.OnClickListener() {
                                     @Override
                                     public void onClick(DialogInterface dialogInterface, int i) {
                                         doImportProject(final_pos);


### PR DESCRIPTION
Fix #1824 QA fail fix verbiage on unsupported import dialog

Changes in this pull request:
- ImportFromDoor43Dialog - changed text on import confirmation dialog ok button to "import".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1913)
<!-- Reviewable:end -->
