### PR TITLE
Fix #1898 large cards displayed

### DIFF
--- a/app/src/main/res/layout/fragment_publish_validation_list_item.xml
+++ b/app/src/main/res/layout/fragment_publish_validation_list_item.xml
@@ -3,17 +3,17 @@
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <FrameLayout
         android:id="@+id/card_container"
         android:visibility="visible"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content">
         <android.support.v7.widget.CardView
             android:id="@+id/stacked_card"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/stacked_card_thin_margin"
             android:layout_marginTop="@dimen/stacked_card_thin_margin"
             android:layout_marginRight="@dimen/card_margin"
@@ -22,7 +22,7 @@
         <android.support.v7.widget.CardView
             android:id="@+id/card"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             card_view:cardElevation="3dp"
             android:layout_marginLeft="@dimen/card_margin"
             android:layout_marginTop="@dimen/card_margin"
@@ -33,7 +33,7 @@
                 android:orientation="vertical"
                 style="@style/Widget.CardContent"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
+                android:layout_height="wrap_content">
 
                 <LinearLayout
                     android:gravity="center_vertical"
@@ -84,7 +84,7 @@
         android:id="@+id/next_layout"
         android:orientation="horizontal"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/card_margin"
         android:gravity="right">
         <Button

--- a/app/src/main/res/layout/fragment_questionnaire_boolean_question.xml
+++ b/app/src/main/res/layout/fragment_questionnaire_boolean_question.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     card_view:cardElevation="2dp"
     android:layout_margin="@dimen/card_margin"
     android:padding="0dp"

--- a/app/src/main/res/layout/fragment_questionnaire_text_question.xml
+++ b/app/src/main/res/layout/fragment_questionnaire_text_question.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     card_view:cardElevation="2dp"
     android:layout_margin="@dimen/card_margin"
     android:padding="0dp"


### PR DESCRIPTION
Fix #1898 large cards displayed

Changes in this pull request:
- Fixed layout for recycleview cards so that they wrap content rather than the height of the parent.  Fixed review cards and new questions cards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1919)
<!-- Reviewable:end -->
