### PR TITLE
Fix #1845 inconsistencies in TW downloads

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesAdapter.java
@@ -39,7 +39,6 @@ public class DownloadSourcesAdapter  extends BaseAdapter {
     private final Context mContext;
     private List<String> mSelected = new ArrayList<>();
     private List<String> mDownloaded = new ArrayList<>();
-    private List<String> mDownloadError = new ArrayList<>();
     private List<ViewItem> mItems = new ArrayList<>();
     private List<Translation> mAvailableSources;
     private Map<String,List<Integer>> mByLanguage;
@@ -57,7 +56,7 @@ public class DownloadSourcesAdapter  extends BaseAdapter {
     private String mLanguageFilter;
     private String mBookFilter;
     private String mSearch = null;
-    private Map<String, String> mDownloadErrorMessages = new HashMap<>();
+    private Map<String, String> mDownloadErrors = new HashMap<>();
 
     public DownloadSourcesAdapter(Context context) {
         mContext = context;
@@ -153,10 +152,6 @@ a     * @param task
         return mDownloaded;
     }
 
-    public List<String> getDownloadError() {
-        return mDownloadError;
-    }
-
     public void setSelected(List<String> mSelected) {
         this.mSelected = mSelected;
     }
@@ -165,16 +160,12 @@ a     * @param task
         this.mDownloaded = mDownloaded;
     }
 
-    public void setDownloadError(List<String> mDownloadError) {
-        this.mDownloadError = mDownloadError;
-    }
-
     public JSONObject getDownloadErrorMessages() {
-        return new JSONObject(mDownloadErrorMessages);
+        return new JSONObject(mDownloadErrors);
     }
 
     public void setDownloadErrorMessages(String jsonDownloadErrorMessagesStr) {
-        mDownloadErrorMessages.clear();
+        mDownloadErrors.clear();
         try {
             JSONObject jsonMessages = new JSONObject(jsonDownloadErrorMessagesStr);
             Iterator<?> keyset = jsonMessages.keys();
@@ -182,7 +173,7 @@ a     * @param task
                 String key = (String) keyset.next();
                 Object value = jsonMessages.get(key);
                 if(value != null) {
-                    mDownloadErrorMessages.put(key, value.toString());
+                    mDownloadErrors.put(key, value.toString());
                 }
             }
         } catch (Exception e) {
@@ -456,11 +447,9 @@ a     * @param task
         if(mDownloaded.contains(newItem.containerSlug)) {
             newItem.downloaded = true;
         }
-        if(mDownloadError.contains(newItem.containerSlug)) {
+        if(mDownloadErrors.containsKey(newItem.containerSlug)) {
             newItem.error = true;
-            if(mDownloadErrorMessages.containsKey(newItem.containerSlug)) {
-                newItem.errorMessage = mDownloadErrorMessages.get(newItem.containerSlug);
-            }
+            newItem.errorMessage = mDownloadErrors.get(newItem.containerSlug);
         }
         mItems.add(newItem);
     }
@@ -736,8 +725,7 @@ a     * @param task
             if(!mDownloaded.contains(item.containerSlug)) {
                 mDownloaded.add(item.containerSlug);
             }
-            mDownloadError.remove(item.containerSlug);
-            mDownloadErrorMessages.remove(item.containerSlug);
+            mDownloadErrors.remove(item.containerSlug);
         }
     }
 
@@ -751,10 +739,7 @@ a     * @param task
             item.error = true;
             item.errorMessage = message;
 
-            if(!mDownloadError.contains(item.containerSlug)) {
-                mDownloadError.add(item.containerSlug);
-                mDownloadErrorMessages.put(item.containerSlug, message);
-            }
+            mDownloadErrors.put(item.containerSlug, message);
             mDownloaded.remove(item.containerSlug);
         }
     }

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesAdapter.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -90,11 +91,14 @@ a     * @param task
      * loads the filter stages (e.g. filter by language, and then by category)
      * @param steps
      * @param search - string to search for
+     * @param restore - if true then don't reset selection list
      */
-    public void setFilterSteps(List<DownloadSourcesAdapter.FilterStep> steps, String search) {
+    public void setFilterSteps(List<DownloadSourcesAdapter.FilterStep> steps, String search, boolean restore) {
         mSteps = steps;
         mSearch = search;
-        mSelected = new ArrayList<>(); // clear selections
+        if(!restore) {
+            mSelected = new ArrayList<>(); // clear selections
+        }
         initializeSelections();
     }
 
@@ -163,6 +167,27 @@ a     * @param task
 
     public void setDownloadError(List<String> mDownloadError) {
         this.mDownloadError = mDownloadError;
+    }
+
+    public JSONObject getDownloadErrorMessages() {
+        return new JSONObject(mDownloadErrorMessages);
+    }
+
+    public void setDownloadErrorMessages(String jsonDownloadErrorMessagesStr) {
+        mDownloadErrorMessages.clear();
+        try {
+            JSONObject jsonMessages = new JSONObject(jsonDownloadErrorMessagesStr);
+            Iterator<?> keyset = jsonMessages.keys();
+            while (keyset.hasNext()) {
+                String key = (String) keyset.next();
+                Object value = jsonMessages.get(key);
+                if(value != null) {
+                    mDownloadErrorMessages.put(key, value.toString());
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     public SelectedState getSelectedState() {

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
@@ -90,6 +90,7 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
 
         ManagedTask task = new GetAvailableSourcesTask();
         ((GetAvailableSourcesTask)task).setPrefix(this.getResources().getString(R.string.loading_sources));
+        createProgressDialog(task);
         task.addOnProgressListener(this);
         task.addOnFinishedListener(this);
         mGetAvailableSourcesTaskID = TaskManager.addTask(task);

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
@@ -60,7 +60,6 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
     public static final String STATE_BY_LANGUAGE_FLAG = "state_by_language_flag";
     public static final String STATE_SELECTED_LIST = "state_selected_list";
     public static final String STATE_DOWNLOADED_LIST = "state_downloaded_list";
-    public static final String STATE_DOWNLOADED_ERRORS_LIST = "state_downloaded_errors_list";
     public static final String STATE_DOWNLOADED_ERROR_MESSAGES = "state_downloaded_error_messages";
     public static final boolean RESTORE = true;
     private Door43Client mLibrary;
@@ -272,8 +271,6 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
             mAdapter.setSelected(mSelected);
             List<String> downloaded = savedInstanceState.getStringArrayList(STATE_DOWNLOADED_LIST);
             mAdapter.setDownloaded(downloaded);
-            List<String> downloadError = savedInstanceState.getStringArrayList(STATE_DOWNLOADED_ERRORS_LIST);
-            mAdapter.setDownloadError(downloadError);
             String errorMsgsJson = savedInstanceState.getString(STATE_DOWNLOADED_ERROR_MESSAGES, null);
             mAdapter.setDownloadErrorMessages(errorMsgsJson);
 
@@ -352,7 +349,6 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
         if(mAdapter != null) {
             out.putStringArrayList(STATE_SELECTED_LIST, (ArrayList) mAdapter.getSelected());
             out.putStringArrayList(STATE_DOWNLOADED_LIST, (ArrayList) mAdapter.getDownloaded());
-            out.putStringArrayList(STATE_DOWNLOADED_ERRORS_LIST, (ArrayList) mAdapter.getDownloadError());
             out.putString(STATE_DOWNLOADED_ERROR_MESSAGES,  mAdapter.getDownloadErrorMessages().toString());
         }
 

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
@@ -680,14 +680,9 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
                         errors = "\n" + getActivity().getResources().getString(R.string.downloads_fail, failedSourceDownloads.size());
                     }
 
-                    List<String> failedNotesDownloads = downloadSourcesTask.getFailedNotesDownloads();
-                    if(failedNotesDownloads.size() > 0) {
-                        errors += "\n" + getActivity().getResources().getString(R.string.notes_download_errors, failedNotesDownloads.toString());
-                    }
-
-                    List<String> failedQuestionsDownloads = downloadSourcesTask.getFailedQuestionsDownloads();
-                    if(failedQuestionsDownloads.size() > 0) {
-                        errors += "\n" + getActivity().getResources().getString(R.string.questions_download_errors, failedQuestionsDownloads.toString());
+                    List<String> failedHelpsDownloads = downloadSourcesTask.getFailedHelpsDownloads();
+                    if(failedHelpsDownloads.size() > 0) {
+                        errors += "\n" + getActivity().getResources().getString(R.string.helps_download_errors, failedHelpsDownloads.toString());
                     }
 
                     mAdapter.notifyDataSetChanged();

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
@@ -317,13 +317,6 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
         float screenWidthFactor = desiredWidth /correctedWidth;
         screenWidthFactor = Math.min(screenWidthFactor, 1f); // sanity check
         getDialog().getWindow().setLayout((int) (width * screenWidthFactor), WindowManager.LayoutParams.MATCH_PARENT);
-
-        ManagedTask downloadTask = TaskManager.getTask(TASK_DOWNLOAD_SOURCES);
-        if(downloadTask != null) {
-            createProgressDialog(downloadTask);
-            downloadTask.addOnProgressListener(this);
-            downloadTask.addOnFinishedListener(this);
-        }
     }
 
     @Override
@@ -807,7 +800,15 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
             }
         }
         ManagedTask task = TaskManager.getTask(TASK_DOWNLOAD_SOURCES);
-        if(task != null) TaskManager.cancelTask(task);
+        if(task != null) {
+            task.removeOnProgressListener(this);
+            task.removeOnFinishedListener(this);
+            TaskManager.cancelTask(task);
+        }
+
+        if (mProgressDialog != null) {
+            mProgressDialog.dismiss();
+        }
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -935,8 +935,7 @@ Do you want to enable SD card access?  If so then:
     <string name="downloads_fail"><xliff:g example="6" id="fail_count">%1$d</xliff:g> Source downloads have failed.</string>
     <string name="download_cancelled">Download Cancelled</string>
     <string name="download_errors">Download Errors</string>
-    <string name="notes_download_errors">Notes failed to download for: <xliff:g example="en_obs,fr_obs" id="fails">%1$s</xliff:g></string>
-    <string name="questions_download_errors">Questions failed to download for: <xliff:g example="en_obs,fr_obs" id="fails">%1$s</xliff:g></string>
+    <string name="helps_download_errors">Helps failed to download for: <xliff:g example="en_obs,fr_obs" id="fails">%1$s</xliff:g></string>
     <string name="source_not_found">Source Not Found on Server</string>
     <string name="search_for_language">Search for Language</string>
     <string name="sort_column">Column to Sort By</string>


### PR DESCRIPTION
Fix #1845 inconsistencies in TW downloads

Changes in this pull request:
- DownloadResourceContainersTask - Consolidated code for downloading helps. Added support for downloading translation words.
- DownloadSourcesDialog - Moved creation of ProgressDialog outside of progress update loop to simplify and hopefully reduce risk of errors.
- DownloadSourcesAdapter - fixes to completely restore state after orientation change.  Removed redundant mDownloadError list.
- DownloadSourcesDialog - fixes to reconnect to existing source download task.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1927)
<!-- Reviewable:end -->
