### PR TITLE
Fix #1929 overwrite warning on print

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.6.1'
     }
 }

--- a/app/src/main/java/com/door43/translationstudio/core/ExportUsfm.java
+++ b/app/src/main/java/com/door43/translationstudio/core/ExportUsfm.java
@@ -158,6 +158,7 @@ public class ExportUsfm {
         if( (tempFile != null) && (outputFileName != null) ) {
             if(outputToDocumentFile) {
                 try {
+                    SdUtils.documentFileDelete( destinationFolder, outputFileName); // make sure file does not exist, otherwise api will create a duplicate file in next line
                     DocumentFile sdCardFile = SdUtils.documentFileCreate(destinationFolder, outputFileName);
                     OutputStream outputStream = SdUtils.createOutputStream(sdCardFile);
                     BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(outputStream);

--- a/app/src/main/java/com/door43/translationstudio/tasks/ExportProjectTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/ExportProjectTask.java
@@ -50,6 +50,7 @@ public class ExportProjectTask extends ManagedTask {
 
         try {
             if (isOutputToDocumentFile) {
+                SdUtils.documentFileDelete( path, filename); // make sure file does not exist, otherwise api will create a duplicate file in next line
                 sdCardFile = SdUtils.documentFileCreate(path, filename);
                 filePath = SdUtils.getPathString(sdCardFile);
                 out = SdUtils.createOutputStream(sdCardFile);

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
@@ -303,12 +303,12 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
                         showUsfmExportResults(mDialogMessage);
                         break;
 
-                    case EXPORT_PROJECT_CONFLICT:
-                        showExportProjectConflict(mDialogMessage);
+                    case EXPORT_PROJECT_OVERWRITE:
+                        showExportProjectOverwrite(mDialogMessage);
                         break;
 
-                    case EXPORT_USFM_CONFLICT:
-                        showExportUsfmConflict(mDialogMessage);
+                    case EXPORT_USFM_OVERWRITE:
+                        showExportUsfmOverwrite(mDialogMessage);
                         break;
 
                     case NONE:
@@ -400,12 +400,12 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
                                 {
                                     boolean conflict = !saveToUsfm(targetTranslation, destinationFilename, false);
                                     if(conflict) {
-                                        showExportUsfmConflict(destinationFilename);
+                                        showExportUsfmOverwrite(destinationFilename);
                                     }
                                 } else {
                                     boolean conflict = !saveProjectFile(targetTranslation, destinationFilename, false);
                                     if(conflict) {
-                                        showExportProjectConflict(destinationFilename);
+                                        showExportProjectOverwrite(destinationFilename);
                                     }
                                 }
                             }
@@ -421,8 +421,8 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
      * display confirmation prompt before USFM export (also allow entry of filename)
      * @param fileName
      */
-    private void showExportUsfmConflict(final String fileName) {
-        mDialogShown = eDialogShown.EXPORT_USFM_CONFLICT;
+    private void showExportUsfmOverwrite(final String fileName) {
+        mDialogShown = eDialogShown.EXPORT_USFM_OVERWRITE;
         mDialogMessage = fileName;
         String path = SdUtils.getPathString(mDestinationFolderUri, fileName);
         String message = getString(R.string.overwrite_file_warning, path);
@@ -457,8 +457,8 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
      * display confirmation prompt before Project export (also allow entry of filename)
      * @param fileName
      */
-    private void showExportProjectConflict(final String fileName) {
-        mDialogShown = eDialogShown.EXPORT_PROJECT_CONFLICT;
+    private void showExportProjectOverwrite(final String fileName) {
+        mDialogShown = eDialogShown.EXPORT_PROJECT_OVERWRITE;
         mDialogMessage = fileName;
         String path = SdUtils.getPathString(mDestinationFolderUri, fileName);
         String message = getString(R.string.overwrite_file_warning, path);
@@ -1043,8 +1043,8 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
         EXPORT_TO_USFM_PROMPT(8),
         EXPORT_TO_USFM_RESULTS(9),
         NO_INTERNET(10),
-        EXPORT_PROJECT_CONFLICT(11),
-        EXPORT_USFM_CONFLICT(12);
+        EXPORT_PROJECT_OVERWRITE(11),
+        EXPORT_USFM_OVERWRITE(12);
 
         private int value;
 

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
@@ -303,6 +303,14 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
                         showUsfmExportResults(mDialogMessage);
                         break;
 
+                    case EXPORT_PROJECT_CONFLICT:
+                        showExportProjectConflict(mDialogMessage);
+                        break;
+
+                    case EXPORT_USFM_CONFLICT:
+                        showExportUsfmConflict(mDialogMessage);
+                        break;
+
                     case NONE:
                         break;
 
@@ -355,10 +363,9 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
      */
     private void showExportToUsfmPrompt() {
         mDialogShown = eDialogShown.EXPORT_TO_USFM_PROMPT;
-        int titleId = R.string.usfm_output_filename_title_prompt;
         ExportUsfm.BookData bookData = ExportUsfm.BookData.generate(targetTranslation);
         String defaultFileName = bookData.getDefaultUsfmFileName();
-        showExportPathPrompt(titleId, defaultFileName);
+        showExportPathPrompt(R.string.usfm_output_filename_title_prompt, defaultFileName);
     }
 
     /**
@@ -366,10 +373,8 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
      */
     private void showExportProjectPrompt() {
         mDialogShown = eDialogShown.EXPORT_PROJECT_PROMPT;
-        int titleId = R.string.project_output_filename_title_prompt;
         String filename = targetTranslation.getId() + "." + Translator.ARCHIVE_EXTENSION;
-        filename = System.currentTimeMillis() / 1000L + "_" + filename;
-        showExportPathPrompt(titleId, filename);
+        showExportPathPrompt(R.string.project_output_filename_title_prompt, filename);
     }
 
     /**
@@ -393,9 +398,15 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
                                 String destinationFilename = filenameText.getText().toString();
                                 if(isUsfmExport)
                                 {
-                                    saveToUsfm(targetTranslation, destinationFilename);
+                                    boolean conflict = !saveToUsfm(targetTranslation, destinationFilename, false);
+                                    if(conflict) {
+                                        showExportUsfmConflict(destinationFilename);
+                                    }
                                 } else {
-                                    saveProjectFile(targetTranslation, destinationFilename);
+                                    boolean conflict = !saveProjectFile(targetTranslation, destinationFilename, false);
+                                    if(conflict) {
+                                        showExportProjectConflict(destinationFilename);
+                                    }
                                 }
                             }
                         })
@@ -407,14 +418,92 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
     }
 
     /**
+     * display confirmation prompt before USFM export (also allow entry of filename)
+     * @param fileName
+     */
+    private void showExportUsfmConflict(final String fileName) {
+        mDialogShown = eDialogShown.EXPORT_USFM_CONFLICT;
+        mDialogMessage = fileName;
+        String path = SdUtils.getPathString(mDestinationFolderUri, fileName);
+        String message = getString(R.string.overwrite_file_warning, path);
+        new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
+                .setTitle(R.string.overwrite_file_title)
+                .setMessage(message)
+                .setPositiveButton(R.string.overwrite_label, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        mDialogShown = eDialogShown.NONE;
+                        saveToUsfm(targetTranslation, fileName, true);
+                    }
+                })
+                .setNeutralButton(R.string.title_cancel, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        mDialogShown = eDialogShown.NONE;
+                        dialog.dismiss();
+                    }
+                })
+                .setNegativeButton(R.string.rename_label, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        mDialogShown = eDialogShown.EXPORT_TO_USFM_PROMPT;
+                        showExportPathPrompt(R.string.usfm_output_filename_title_prompt, fileName);
+                    }
+                })
+                .show();
+    }
+
+    /**
+     * display confirmation prompt before Project export (also allow entry of filename)
+     * @param fileName
+     */
+    private void showExportProjectConflict(final String fileName) {
+        mDialogShown = eDialogShown.EXPORT_PROJECT_CONFLICT;
+        mDialogMessage = fileName;
+        String path = SdUtils.getPathString(mDestinationFolderUri, fileName);
+        String message = getString(R.string.overwrite_file_warning, path);
+        new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
+                .setTitle(R.string.overwrite_file_title)
+                .setMessage(message)
+                .setPositiveButton(R.string.overwrite_label, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        mDialogShown = eDialogShown.NONE;
+                        saveProjectFile(targetTranslation, fileName, true);
+                    }
+                })
+                .setNeutralButton(R.string.title_cancel, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        mDialogShown = eDialogShown.NONE;
+                        dialog.dismiss();
+                    }
+                })
+                .setNegativeButton(R.string.rename_label, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        mDialogShown = eDialogShown.EXPORT_PROJECT_PROMPT;
+                        showExportPathPrompt(R.string.project_output_filename_title_prompt, fileName);
+                    }
+                })
+                .show();
+    }
+
+    /**
      * save to usfm file and give success notification
      * @param targetTranslation
+     * @param force - if true then we will overwrite existing file
+     * @return false if not forced and file already is present
      */
-    private void saveToUsfm(TargetTranslation targetTranslation, String fileName) {
+    private boolean saveToUsfm(TargetTranslation targetTranslation, String fileName, boolean force) {
+        if(!force && SdUtils.exists(mDestinationFolderUri, fileName)) {
+            return false;
+        }
         initProgressWatcher(R.string.exporting);
         ExportToUsfmTask usfmExportTask = new ExportToUsfmTask(getActivity(), targetTranslation, mDestinationFolderUri, fileName, isOutputToDocumentFile);
         taskWatcher.watch(usfmExportTask);
         TaskManager.addTask(usfmExportTask, ExportToUsfmTask.TASK_ID);
+        return true;
     }
 
     /**
@@ -466,12 +555,18 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
     /**
      * back up project - will try to write to user selected destination
      * @param filename
+     * @param force - if true then we will overwrite existing file
+     * @return false if not forced and file already is present
      */
-    private void saveProjectFile(TargetTranslation targetTranslation, String filename) {
+    private boolean saveProjectFile(TargetTranslation targetTranslation, String filename, boolean force) {
+        if(!force && SdUtils.exists(mDestinationFolderUri, filename)) {
+            return false;
+        }
         initProgressWatcher(R.string.exporting);
         ExportProjectTask sdExportTask = new ExportProjectTask(getActivity(), filename, mDestinationFolderUri, targetTranslation);
         taskWatcher.watch(sdExportTask);
         TaskManager.addTask(sdExportTask, ExportProjectTask.TASK_ID);
+        return true;
     }
 
     /**
@@ -947,7 +1042,9 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
         MERGE_CONFLICT(7),
         EXPORT_TO_USFM_PROMPT(8),
         EXPORT_TO_USFM_RESULTS(9),
-        NO_INTERNET(10);
+        NO_INTERNET(10),
+        EXPORT_PROJECT_CONFLICT(11),
+        EXPORT_USFM_CONFLICT(12);
 
         private int value;
 

--- a/app/src/main/java/com/door43/util/SdUtils.java
+++ b/app/src/main/java/com/door43/util/SdUtils.java
@@ -531,7 +531,7 @@ public class SdUtils {
      * @return
      */
     public static OutputStream createOutputStream(DocumentFile outputFile) throws FileNotFoundException {
-        OutputStream out = App.context().getContentResolver().openOutputStream(outputFile.getUri());
+        OutputStream out = App.context().getContentResolver().openOutputStream(outputFile.getUri(), "w");
         return new BufferedOutputStream(out); // add buffering to improve performance on writing to SD card
     }
 
@@ -545,6 +545,26 @@ public class SdUtils {
         DocumentFile documentFileFolder = getDocumentFileFolder(baseUri);
         DocumentFile documentFile = documentFileCreate(documentFileFolder, fileName);
         return documentFile;
+    }
+
+    /**
+     * deletes a DocumentFile in Uri.
+     * @param baseUri - base folder
+     * @param fileName - name of subfolder to move to
+     * @return
+     */
+    public static boolean documentFileDelete(final Uri baseUri, final String fileName) {
+        try {
+            DocumentFile documentFileFolder = getDocumentFileFolder(baseUri);
+            DocumentFile file = documentFileFolder.findFile(fileName);
+            if(file != null) {
+                file.delete();
+            }
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return false;
     }
 
     /**
@@ -729,5 +749,43 @@ public class SdUtils {
         }
         String scheme = folderUri.getScheme();
         return "file".equalsIgnoreCase(scheme);
+    }
+
+    /**
+     * method to determine if file exists, handles DocumentFile type as well as File
+     * @param path
+     * @param filename
+     * @return
+     */
+    public static boolean exists(Uri path, String filename) {
+        boolean isOutputToDocumentFile = !SdUtils.isRegularFile(path);
+        if(isOutputToDocumentFile) {
+            DocumentFile sdCardFolder = getDocumentFileFolder(path);
+            if(sdCardFolder == null) {
+                return false;
+            }
+            DocumentFile sdCardFile = sdCardFolder.findFile(filename);
+            return (sdCardFile != null);
+        }
+
+        File exportFile = new File(path.getPath(), filename);
+        return exportFile.exists();
+    }
+
+    /**
+     * Gets human readable path string
+     * @param path
+     * @param filename
+     * @return
+     */
+    public static String getPathString(Uri path, String filename) {
+        boolean isOutputToDocumentFile = !SdUtils.isRegularFile(path);
+        if(isOutputToDocumentFile) {
+            String pathStr = getPathString(path.toString());
+            return pathStr + "/" + filename;
+        }
+
+        File exportFile = new File(path.getPath(), filename);
+        return exportFile.toString();
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -962,4 +962,8 @@ Do you want to enable SD card access?  If so then:
     <string name="translation_academy">Translation Academy</string>
     <string name="unsupported">Unsupported</string>
     <string name="import_warning">The project \'<xliff:g example="MysteryProject" id="project_name">%1$s</xliff:g>\' may not be supported in this app.  Currently, translationStudio only supports Scripture and Open Bible Stories projects. If this is not one of those types of projects it will not be imported into translationStudio.\n\nDo you want to try to import it anyway?</string>
+    <string name="overwrite_file_title">Overwrite File?</string>
+    <string name="overwrite_file_warning">The same filename already exists.  Do you want to overwrite\n<xliff:g example="project.usfm" id="project_name">%1$s</xliff:g>?</string>
+    <string name="overwrite_label">Overwrite</string>
+    <string name="rename_label">Rename</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Sep 02 10:17:54 PDT 2016
+#Fri Mar 03 13:19:01 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
Fix #1929 overwrite warning on print
Also Includes fixes in PR #1939 

Changes in this pull request:
- PrintDialog - fix for SD Card file overwrite. Now prompts user if file already exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1940)
<!-- Reviewable:end -->
