### PR TITLE
Fix #1949 crash on selecting new source

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationAdapter.java
@@ -352,12 +352,14 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
 
         holder.titleView.setText(item.title);
         if( (rowType == TYPE_ITEM_NEED_DOWNLOAD) || (rowType == TYPE_ITEM_SELECTABLE_UPDATABLE)) {
-            if(rowType == TYPE_ITEM_NEED_DOWNLOAD) {
-                holder.downloadView.setBackgroundResource(R.drawable.ic_file_download_black_24dp);
-            } else {
-                holder.downloadView.setBackgroundResource(R.drawable.ic_refresh_black_24dp);
+            if(holder.downloadView != null) {
+                if (rowType == TYPE_ITEM_NEED_DOWNLOAD) {
+                    holder.downloadView.setBackgroundResource(R.drawable.ic_file_download_black_24dp);
+                } else {
+                    holder.downloadView.setBackgroundResource(R.drawable.ic_refresh_black_24dp);
+                }
+                ViewUtil.tintViewDrawable(holder.downloadView, parent.getContext().getResources().getColor(R.color.accent));
             }
-            ViewUtil.tintViewDrawable(holder.downloadView, parent.getContext().getResources().getColor(R.color.accent));
         }
 
         if((rowType == TYPE_ITEM_SELECTABLE) || (rowType == TYPE_ITEM_SELECTABLE_UPDATABLE)){


### PR DESCRIPTION
Fix #1949 crash on selecting new source

Changes in this pull request:
- ChooseSourceTranslationAdapter - fix for null pointer error on source selection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1950)
<!-- Reviewable:end -->
