### PR TITLE
Fix 1932 extra cards in review

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/publish/ValidationFragment.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/publish/ValidationFragment.java
@@ -58,7 +58,7 @@ public class ValidationFragment extends PublishStepFragment implements ManagedTa
             task.addOnFinishedListener(this);
         } else {
             // start new task
-            task = new ValidationTask(targetTranslationId, sourceTranslationId);
+            task = new ValidationTask(getActivity(), targetTranslationId, sourceTranslationId);
             task.addOnFinishedListener(this);
             TaskManager.addTask(task);
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -969,4 +969,7 @@ Do you want to enable SD card access?  If so then:
     <string name="bytes_short">B</string>
     <string name="kilobytes_short">KB</string>
     <string name="megabytes_short">MB</string>
+    <string name="has_warnings">\'<xliff:g example="Chapter 1" id="title">%1$s</xliff:g>\' has warnings:</string>
+    <string name="title">Title</string>
+    <string name="reference">Reference</string>
 </resources>


### PR DESCRIPTION
Fix #1932 extra cards in review

Changes in this pull request:
- ValidationTask - fixed double entry of title and reference cards.  Added additional tip text to group cards, titles, and references to help user differentiate them from chunks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1951)
<!-- Reviewable:end -->
