### PR TITLE
Fix 1961 scroll bar position when searching

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -868,7 +868,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
     }
 
     /**
-     * highlist the current selected search text item at position
+     * highlight the current selected search text item at position
      * @param position - list item position
      * @param selectPosition
      * @param view
@@ -889,6 +889,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
                 hand.post(new Runnable() {
                     @Override
                     public void run() {
+                        Log.i(TAG, "selectCurrentSearchItem position= " + position + ", offset=" +(-verticalOffset));
                         onSetSelectedPosition(position, -verticalOffset);
                     }
                 });
@@ -1948,6 +1949,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
             mSearchPosition = foundPos;
             mSearchSubPositionItems = -1;
             if(getListener() != null) {
+                Log.i(TAG, "onMoveSearch position= " + foundPos);
                 getListener().onSetSelectedPosition(foundPos, 0); // coarse scrolling
             }
             onSearching(false, mNumberOfChunkMatches, false, false);
@@ -1955,10 +1957,9 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
             ReviewListItem item = (ReviewListItem) getItem(mSearchPosition);
             if(item != null) {
                 findSearchItemInChunkAndPreselect(forward, item, mSearchingTarget);
-                triggerNotifyDataSetChanged();
             }
         } else { // not found, clear last selection
-            Log.i(TAG, "onMoveSearch at end = " + mSearchPosition);
+            Log.i(TAG, "onMoveSearch at limit = " + mSearchPosition);
             ReviewListItem item = (ReviewListItem) getItem(mSearchPosition);
             if(item != null) {
                 forceSearchReRender(item);
@@ -2210,6 +2211,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
                         @Override
                         public void run() {
                             mSearchPosition = initialPosition;
+                            mLayoutBuildNumber++; // force redraw of displayed cards
                             triggerNotifyDataSetChanged();
                             boolean zeroItemsFound = ReviewModeAdapter.this.mChunkSearchMatchesCounter <= 0;
                             onSearching(false, ReviewModeAdapter.this.mChunkSearchMatchesCounter, zeroItemsFound, zeroItemsFound);

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeFragment.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeFragment.java
@@ -13,6 +13,7 @@ import android.os.Looper;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.GestureDetector;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -534,6 +535,7 @@ public abstract class ViewModeFragment extends BaseFragment implements ViewModeA
      */
     public void onScrollProgressUpdate(int scrollProgress, int percent) {
         mFingerScroll = false;
+        Log.d(TAG, "onScrollProgressUpdate: scrollProgress=" + scrollProgress + ", percent=" + percent);
         if(percent == 0) {
             mRecyclerView.scrollToPosition(scrollProgress);
         } else {
@@ -756,6 +758,7 @@ public abstract class ViewModeFragment extends BaseFragment implements ViewModeA
      * @param offset - if greater than or equal to 0, then set specific offset
      */
     public void onSetSelectedPosition(int position, int offset) {
+        Log.d(TAG, "onSetSelectedPosition: position=" + position + ", offset=" + offset);
         doScrollToPosition(position, offset);
     }
 


### PR DESCRIPTION


Fix #1961 scroll bar position when searching

Changes in this pull request:
- TargetTranslationActivity - make sure item count has changed before changing seekbar maximum in order to reduce seekbar thrashing, and also update progress proportionally on maximum change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1968)
<!-- Reviewable:end -->
