### PR TITLE
Fix #1845 QA fail disable progressbar click off cancel on update sources

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
@@ -768,7 +768,6 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
         mProgressDialog.setCancelable(false);
         mProgressDialog.setCanceledOnTouchOutside(false);
         mProgressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
-        mProgressDialog.setOnCancelListener(DownloadSourcesDialog.this);
         mProgressDialog.setIcon(R.drawable.ic_cloud_download_black_24dp);
         mProgressDialog.setTitle(R.string.updating);
         mProgressDialog.setMessage("");
@@ -776,6 +775,17 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
         mProgressDialog.setButton(DialogInterface.BUTTON_NEGATIVE, "Cancel", new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
                 TaskManager.cancelTask(task);
+
+                // put dialog back up until download is actually stopped
+                Handler hand = new Handler(Looper.getMainLooper());
+                hand.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        if(mProgressDialog != null) {
+                            mProgressDialog.show();
+                        }
+                    }
+                });
             }
         });
         Handler hand = new Handler(Looper.getMainLooper());

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
@@ -765,8 +765,8 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
      */
     protected void createProgressDialog(final ManagedTask task) {
         mProgressDialog = new ProgressDialog(getActivity());
-        mProgressDialog.setCancelable(true);
-        mProgressDialog.setCanceledOnTouchOutside(true);
+        mProgressDialog.setCancelable(false);
+        mProgressDialog.setCanceledOnTouchOutside(false);
         mProgressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
         mProgressDialog.setOnCancelListener(DownloadSourcesDialog.this);
         mProgressDialog.setIcon(R.drawable.ic_cloud_download_black_24dp);

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -368,10 +368,6 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
      * @param position the position that will be garbage collected
      */
     private void runTaskGarbageCollection(int position) {
-        if((position < 0) || (position >= mItems.size())) { // sanity check on position value
-            return;
-        }
-
         ListItem item = mItems.get(position);
 
         // source

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -368,6 +368,10 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
      * @param position the position that will be garbage collected
      */
     private void runTaskGarbageCollection(int position) {
+        if((position < 0) || (position >= mItems.size())) { // sanity check on position value
+            return;
+        }
+
         ListItem item = mItems.get(position);
 
         // source


### PR DESCRIPTION
Fix #1845 QA fail disable progressbar click off cancel on update sources

Changes in this pull request:
- DownloadSourcesDialog - download progress dialog is no longer cancellable by clicking off.
- DownloadSourcesDialog - fix issue that cancel dismisses progress dialog immediately even though actual download cancel may be a long time later. We pop the dialog back up until task is finished.  This lets the user know that the task is not done yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1977)
<!-- Reviewable:end -->
