### PR TITLE
Fix #1980 change footnote title from Note to Footnote

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -1717,7 +1717,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
      */
     private void showFootnote(final ReviewHolder holder, final ReviewListItem item, final NoteSpan span, final int start, final int end, boolean editable) {
         CharSequence marker = span.getPassage();
-        CharSequence title = mContext.getResources().getText(R.string.title_note);
+        CharSequence title = mContext.getResources().getText(R.string.title_footnote);
         if(!marker.toString().isEmpty()) {
             title = title + ": " + marker;
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -972,4 +972,5 @@ Do you want to enable SD card access?  If so then:
     <string name="has_warnings">\'<xliff:g example="Chapter 1" id="title">%1$s</xliff:g>\' has warnings:</string>
     <string name="title">Title</string>
     <string name="reference">Reference</string>
+    <string name="title_footnote">FootNote</string>
 </resources>


### PR DESCRIPTION
Fix #1980 change footnote title from Note to Footnote

Changes in this pull request:
- ReviewModeAdapter - changed footnote title from Note to Footnote.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1986)
<!-- Reviewable:end -->
