### PR TITLE
Fix #1638 QA fail - fix sd card prompt and Kitkat support

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/devtools/DeveloperToolsActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/devtools/DeveloperToolsActivity.java
@@ -161,7 +161,7 @@ public class DeveloperToolsActivity extends BaseActivity implements ManagedTask.
             mDeveloperTools.add(new ToolItem("Reset SD Card Access", "", R.drawable.ic_warning_black_24dp, new ToolItem.ToolAction() {
                 @Override
                 public void run() {
-                    SdUtils.persistSdCardWriteAccess(Uri.parse("content://com.android.externalstorage.documents/tree/Fail_Me"), 0);
+                    SdUtils.removeSdCardWriteAccess();
                 }
             }));
         }

--- a/app/src/main/java/com/door43/translationstudio/ui/filechooser/FileChooserActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/filechooser/FileChooserActivity.java
@@ -398,10 +398,10 @@ public class FileChooserActivity extends BaseActivity {
                 // Get Uri from Storage Access Framework.
                 treeUri = data.getData();
                 final int takeFlags = data.getFlags();
-                boolean success = SdUtils.validateSdCardWriteAccess(treeUri, takeFlags);
-                if (!success) {
-                    String template = getResources().getString(R.string.access_failed);
-                    msg = String.format(template, treeUri.toString());
+                SdUtils.WriteAccessMode status = SdUtils.validateSdCardWriteAccess(treeUri, takeFlags);
+                if (status != SdUtils.WriteAccessMode.ENABLED_CARD_BASE) {
+                    accessErrorPrompt(this, treeUri, status);
+                    return;
                 } else {
                     msg = getResources().getString(R.string.access_granted_import);
                     showFolderFromSdCard();
@@ -415,6 +415,27 @@ public class FileChooserActivity extends BaseActivity {
                     .setPositiveButton(R.string.label_ok, null)
                     .show();
         }
+    }
+
+    /**
+     * show user how access attempt failed
+     * @param context
+     * @param treeUri
+     * @param status
+     */
+    public static void accessErrorPrompt(Context context, Uri treeUri, SdUtils.WriteAccessMode status) {
+        String msg;
+        if (status == SdUtils.WriteAccessMode.NONE) {
+            msg = context.getResources().getString(R.string.access_failed, treeUri.toString());
+        } else {
+            msg = context.getResources().getString(R.string.access_not_root);
+            SdUtils.removeSdCardWriteAccess(); // invalidate keys since we dont want them
+        }
+        new AlertDialog.Builder(context, R.style.AppTheme_Dialog)
+                .setTitle(R.string.access_title)
+                .setMessage(msg)
+                .setPositiveButton(R.string.label_ok, null)
+                .show();
     }
 
     public enum SelectionMode {

--- a/app/src/main/java/com/door43/translationstudio/ui/filechooser/FileChooserActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/filechooser/FileChooserActivity.java
@@ -166,7 +166,7 @@ public class FileChooserActivity extends BaseActivity {
                 if (SdUtils.doWeNeedToRequestSdCardAccess()) {
                     new AlertDialog.Builder(FileChooserActivity.this, R.style.AppTheme_Dialog)
                         .setTitle(R.string.enable_sd_card_access_title)
-                        .setMessage(Html.fromHtml(getResources().getString(R.string.enable_sd_card_access)))
+                        .setMessage(R.string.enable_sd_card_access)
                         .setPositiveButton(R.string.confirm, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {

--- a/app/src/main/java/com/door43/translationstudio/ui/filechooser/FileChooserActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/filechooser/FileChooserActivity.java
@@ -9,7 +9,6 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.support.v4.provider.DocumentFile;
 import android.support.v7.app.AlertDialog;
-import android.text.Html;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.AdapterView;
@@ -36,6 +35,7 @@ public class FileChooserActivity extends BaseActivity {
     public static final String EXTRA_MODE = "extras_selection-mode";
     public static final String EXTRA_FILTERS = "extras_file-filters";
     public static final String EXTRA_TITLE = "extras_title";
+    public static final String EXTRA_READ_ACCESS = "extras_read_access";
     public static final String EXTRAS_ACCEPTED_EXTENSIONS = "extras_accepted_file_extensions";
     public static final String FOLDER_KEY = "folder";
     public static final String FILE_PATH_KEY = "file_path";
@@ -50,6 +50,7 @@ public class FileChooserActivity extends BaseActivity {
     private TextView mCurrentFolder;
     private ListView mFileList;
     private FileChooserAdapter mAdapter;
+    private boolean mWriteAccess = false;
 
     private DocumentFile mCurrentDir;
 
@@ -86,6 +87,7 @@ public class FileChooserActivity extends BaseActivity {
                 mAcceptedExtensions = extensions.split(",");
             }
             title = args.getString(EXTRA_TITLE, null);
+            mWriteAccess = !args.getBoolean(EXTRA_READ_ACCESS, false);
         }
 
         mUpButton = (ImageButton) findViewById(R.id.up_folder_button);
@@ -102,8 +104,7 @@ public class FileChooserActivity extends BaseActivity {
             setTitle(R.string.title_activity_file_explorer);
         }
 
-        File sdCardFolder = SdUtils.getSdCardDirectory();
-        boolean haveSDCard = sdCardFolder != null;
+        boolean haveSDCard = SdUtils.isSdCardAccessableInMode(mWriteAccess);
         showSdCardOption(haveSDCard);
 
         mUpButton.setOnClickListener(new View.OnClickListener() {
@@ -260,10 +261,10 @@ public class FileChooserActivity extends BaseActivity {
                 loadDocFileList(path);
             }
 
-        } else { // SD card not present or not lollipop
+        } else { // SD card not present or Android version is lower than Lollipop
 
             File sdCardFolder = SdUtils.getSdCardDirectory();
-            if (sdCardFolder != null) {
+            if( (sdCardFolder != null) && SdUtils.isSdCardAccessableInMode(mWriteAccess) ) {
                 if (sdCardFolder.isDirectory() && sdCardFolder.exists() && sdCardFolder.canRead()) {
                     File storagePath = Environment.getExternalStorageDirectory();
                     if(!sdCardFolder.equals(storagePath)) { // make sure it doesn't reflect back to internal memory

--- a/app/src/main/java/com/door43/translationstudio/ui/home/ImportDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/ImportDialog.java
@@ -115,6 +115,7 @@ public class ImportDialog extends DialogFragment implements SimpleTaskWatcher.On
                 Intent intent = new Intent(getActivity(), FileChooserActivity.class);
                 Bundle args = new Bundle();
                 args.putString(FileChooserActivity.EXTRA_MODE, FileChooserActivity.SelectionMode.DIRECTORY.name());
+                intent.putExtra(FileChooserActivity.EXTRA_READ_ACCESS, true);
                 intent.putExtras(args);
                 startActivityForResult(intent, IMPORT_RCONTAINER_REQUEST);
             }
@@ -231,6 +232,7 @@ public class ImportDialog extends DialogFragment implements SimpleTaskWatcher.On
         if(doingUsfmImport) {
             intent.putExtra(FileChooserActivity.EXTRAS_ACCEPTED_EXTENSIONS, "usfm");
         }
+        intent.putExtra(FileChooserActivity.EXTRA_READ_ACCESS, true);
         startActivityForResult(intent, doingUsfmImport ? IMPORT_USFM_REQUEST : IMPORT_TRANSLATION_REQUEST);
     }
 

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
@@ -46,6 +46,7 @@ import com.door43.translationstudio.ui.dialogs.BackupDialog;
 import com.door43.translationstudio.ui.dialogs.FeedbackDialog;
 import com.door43.translationstudio.ui.dialogs.PrintDialog;
 import com.door43.translationstudio.ui.draft.DraftActivity;
+import com.door43.translationstudio.ui.filechooser.FileChooserActivity;
 import com.door43.translationstudio.ui.publish.PublishActivity;
 import com.door43.translationstudio.ui.translate.review.SearchSubject;
 import com.door43.util.SdUtils;
@@ -1274,10 +1275,10 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
                 // Get Uri from Storage Access Framework.
                 treeUri = data.getData();
                 final int takeFlags = data.getFlags();
-                boolean success = SdUtils.validateSdCardWriteAccess(treeUri, takeFlags);
-                if (!success) {
-                    String template = getResources().getString(R.string.access_failed);
-                    msg = String.format(template, treeUri.toString());
+                SdUtils.WriteAccessMode status = SdUtils.validateSdCardWriteAccess(treeUri, takeFlags);
+                if (status != SdUtils.WriteAccessMode.ENABLED_CARD_BASE) {
+                    FileChooserActivity.accessErrorPrompt(this, treeUri, status);
+                    return;
                 } else {
                     msg = getResources().getString(R.string.access_granted_backup);
                 }

--- a/app/src/main/java/com/door43/util/SdUtils.java
+++ b/app/src/main/java/com/door43/util/SdUtils.java
@@ -182,14 +182,13 @@ public class SdUtils {
         }
 
         boolean success = persistSdCardWriteAccess(sdUri, flags);
-
-        String sdCardActualFolder = findSdCardFolder();
-        if(sdCardActualFolder != null) {
-            Logger.i(SdUtils.class.getName(), "found card at = " + sdCardActualFolder);
-        } else {
-            Logger.i(SdUtils.class.getName(), "invalid access Uri = " + sdUri);
-            storeSdCardAccess(null, 0); // clear value since invalid
-            success = false;
+        if(success) {
+            String sdCardActualFolder = findSdCardFolder();
+            if(sdCardActualFolder != null) {
+                Logger.i(SdUtils.class.getName(), "found card at = " + sdCardActualFolder);
+            } else {
+                Logger.i(SdUtils.class.getName(), "we couldn't find actual file path for SD card");
+            }
         }
 
         return success;

--- a/app/src/main/java/com/door43/util/SdUtils.java
+++ b/app/src/main/java/com/door43/util/SdUtils.java
@@ -454,6 +454,7 @@ public class SdUtils {
         }
 
         // otherwise see if we can get folder for SD card
+        alreadyReadSdCardDirectory = false;
         File sdCardFolder = SdUtils.getSdCardDirectory();
         return sdCardFolder != null;
     }

--- a/app/src/main/java/com/door43/util/SdUtils.java
+++ b/app/src/main/java/com/door43/util/SdUtils.java
@@ -52,6 +52,7 @@ import java.util.Locale;
  *  Each device has a unique path for the SD card, and if you use more than one SD card then each one
  *  may have a different path.  So we have to search for it.
  *
+ *   **** Note that there is not a way to write to SD cards on KitKat
  */
 public class SdUtils {
     public static final String DOWNLOAD_FOLDER = "/Download";
@@ -438,6 +439,23 @@ public class SdUtils {
             DocumentFile sdCard = sdCardMkdirs(null);
             return sdCard != null;
         }
+    }
+
+    /**
+     * Checks if the external media is mounted able to be used in desirec mode
+     * @return
+     */
+    public static boolean isSdCardAccessableInMode(boolean writeAccess) {
+        if(writeAccess) {
+            // TRICKY: KITKAT introduced changes to the external media that made sd cards read only.  In Lollipop the user can grant permission
+            if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT) {
+                return false;
+            }
+        }
+
+        // otherwise see if we can get folder for SD card
+        File sdCardFolder = SdUtils.getSdCardDirectory();
+        return sdCardFolder != null;
     }
 
     /**

--- a/app/src/main/java/com/door43/util/SdUtils.java
+++ b/app/src/main/java/com/door43/util/SdUtils.java
@@ -35,24 +35,26 @@ import java.util.Locale;
 /**
  * Created by blm on 12/30/15.
  * Utilities to make it easier to work with SD card access, because there are unique behaviors which
- * each version of Android. There are big changes starting with Lollipop - in particular the special
- * DocumentFile access to SD card.  There are a combination of issues to deal with in this case:
+ * each version of Android. In Kitkat they made the SD Card Read-only - there is no way for a 3rd
+ * party app to write to SD Card - only the apps baked into the device.  Then with Lollipop they
+ * locked up reading and writing to SD Card.  But they provided a way for the user to grant to an
+ * application access to the SD Card.  The app is given a special Uri that they can use with
+ * DocumentFile to access the SD card.  Here is how it works in practice:
  *
  *      The user must first be prompted to enable SD card access (we launch a special activity for
- *      this).  When the user has approved, the API returns a special uri and code.  This special uri
+ *      this).  When the user has approved, the API returns a special Uri and code.  This special Uri
  *      is the base folder for the SD card access and it must be accessed using DocumentFile rather
- *      than File.  Paths for accessing files will be relative to this.
+ *      than File.  Paths for accessing files will be relative to this base Uri.
  *
- *      The special code must be used in combination with the special uri to enable SD card access for
+ *      The special code must be used in combination with the special Uri to enable SD card access for
  *      each session.  We store these values so we don't have to request SD card access from the user
  *      each time, but we can unlock SD card whenever we need to read/write to SD card.
  *
- *      We also need to convert these uri's into readable file paths to display to the user.
+ *      We also need to convert these Uri's into readable file paths to display to the user.
  *
- *  Each device has a unique path for the SD card, and if you use more than one SD card then each one
- *  may have a different path.  So we have to search for it.
- *
- *   **** Note that there is not a way to write to SD cards on KitKat
+ *  Also there are complications from the manufacturers: each device may have an unique path for
+ *  the SD card, and if you use more than one SD card then each one may have a different path.  So
+ *  we have to search for it.
  */
 public class SdUtils {
     public static final String DOWNLOAD_FOLDER = "/Download";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -646,13 +646,13 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
 <![CDATA[
 Do you want to enable SD card access?  If so then:
 \n
-\n\u00A0\u00A0* Click Confirm and wait for access dialog to appear
-\n\u00A0\u00A0* If SD Card is not shown on left, click on menu
-\n\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0(three vertical dots in upper right corner)
-\n\u00A0\u00A0* Click on SD Card on left
-\n\u00A0\u00A0* Click on \'Select "SD Card"\' at bottom
+\n\u00A0\u00A 01) Click \'Confirm\' at bottom of this message.
 \n
-\nIf you press SKIP, then import/backup will be with internal memory.
+\n\u00A0\u00A 02) If there is no SD Card icon on the left - then tap the 3-dot icon on the top right.  Tap on \'Show SD Card.\'
+\n
+\n\u00A0\u00A 03) If the SD Card icon is on left - then tap on the icon. Click on the words \'Select "SD Card"\' at bottom of the window.
+\n
+\nIf you press SKIP, then import/backup will use internal memory.
 ]]>
     </string>
     <string name="access_title">Access Attempt</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -646,11 +646,11 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
 <![CDATA[
 Do you want to enable SD card access?  If so then:
 \n
-\n\u00A0\u00A 01) Click \'Confirm\' at bottom of this message.
+\n\u00A0\u00A0 1) Click \'Confirm\' at bottom of this message.
 \n
-\n\u00A0\u00A 02) If there is no SD Card icon on the left - then tap the 3-dot icon on the top right.  Tap on \'Show SD Card.\'
+\n\u00A0\u00A0 2) If there is no SD Card icon on the left - then tap the 3-dot icon on the top right.  Tap on \'Show SD Card.\'
 \n
-\n\u00A0\u00A 03) If the SD Card icon is on left - then tap on the icon. Click on the words \'Select "SD Card"\' at bottom of the window.
+\n\u00A0\u00A0 3) If the SD Card icon is on left - then tap on the icon. Click on the words \'Select "SD Card"\' at bottom of the window.
 \n
 \nIf you press SKIP, then import/backup will use internal memory.
 ]]>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -650,13 +650,13 @@ Do you want to enable SD card access?  If so then:
 \n
 \n\u00A0\u00A0 2) If there is no SD Card icon on the left - then tap the 3-dot icon on the top right.  Tap on \'Show SD Card.\'
 \n
-\n\u00A0\u00A0 3) If the SD Card icon is on left - then tap on the icon. Click on the words \'Select "SD Card"\' at bottom of the window.
+\n\u00A0\u00A0 3) If the SD Card icon is on left - then tap on the icon. Then click on the words \'Select "SD Card"\' at bottom of the window.
 \n
 \nIf you press SKIP, then import/backup will use internal memory.
 ]]>
     </string>
     <string name="access_title">Access Attempt</string>
-    <string name="access_failed">Failed on access request to:\n%s\nYou may have selected a folder other than the SD CARD base</string>
+    <string name="access_failed">Failed on access request to:\n\'%s\'\nYou may have selected a folder other than the SD CARD base.\nMake sure you pressed the \'SD card\' icon on the left, and then that the button you pressed on the bottom said \'SELECT \"SD card\"\'.</string>
     <string name="access_granted_backup">Success!\nAccess Granted.\nPlease retry SD CARD backup operation.</string>
     <string name="access_granted_import">Success!\nAccess Granted.</string>
     <string name="access_skipped">Access Request Cancelled</string>
@@ -972,4 +972,5 @@ Do you want to enable SD card access?  If so then:
     <string name="has_warnings">\'<xliff:g example="Chapter 1" id="title">%1$s</xliff:g>\' has warnings:</string>
     <string name="title">Title</string>
     <string name="reference">Reference</string>
+    <string name="access_not_root">Failed to enable access to SD card base.\nYou may have selected a folder other than the SD CARD base.\nMake sure you pressed the \'SD card\' icon on the left, and then that the button you pressed on the bottom said \'SELECT \"SD card\"\'.</string>
 </resources>


### PR DESCRIPTION
Fix #1638 QA fail - fix sd card prompt and Kitkat support

Changes in this pull request:
- Fixed error message where user does not select the root folder of the SD card, but some other location.
- Tweak formatting of SD card prompt.
- FileChooserActivity - fixed issue that in SD card prompt the formatting was getting stripped out.  Added special handling for KitKit. Since we can only read from SD cards, but not write. Added flag to enable read access only so that we can at least import from SD card.
- SdUtils - validateSdCardWriteAccess() - fixed bug that if we could find the real path to the SD Card, we would return error.  This is not actually a bug.  It is just an inconvenience if user is trying to match the path to file manager.
- FileChooserActivity - fix in case user has inserted a new card before import/export.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1987)
<!-- Reviewable:end -->
