### PR TITLE
Fix #1979 disable source selection while checking for updates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ android {
         applicationId "com.translationstudio.androidapp"
         minSdkVersion 15
         targetSdkVersion 25
-        versionCode 158
+        versionCode 159
         versionName "11.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     } 

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationAdapter.java
@@ -10,6 +10,7 @@ import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.ImageSpan;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -67,10 +68,10 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
      * If the item id matches an existing item it will be skipped
      * @param item
      */
-    public void addItem(final ViewItem item) {
+    public void addItem(final ViewItem item, boolean selectable) {
         if(!mData.containsKey(item.containerSlug)) {
             mData.put(item.containerSlug, item);
-            if(item.selected  && item.downloaded) {
+            if(item.selected && item.downloaded) {
                 mSelected.add(item.containerSlug);
             } else if(!item.downloaded) {
                 mDownloadable.add(item.containerSlug);
@@ -78,18 +79,61 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
                 mAvailable.add(item.containerSlug);
             }
 
-            if(!item.checkedUpdates && item.downloaded) { // see if there are updates available to download
+            if (selectable) { // see if there are updates available to download
+                Log.i(TAG, "Checking for updates on " + item.containerSlug);
                 boolean hasUpdates = false;
                 try {
                     ResourceContainer container = App.getLibrary().open(item.containerSlug);
                     int lastModified = App.getLibrary().getResourceContainerLastModified(container.language.slug, container.project.slug, container.resource.slug);
                     hasUpdates = (lastModified > container.modifiedAt);
+                    Log.i(TAG, "Checking for updates on " + item.containerSlug + " finished, needs updates: " +hasUpdates);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
                 item.hasUpdates = hasUpdates;
                 item.checkedUpdates = true;
             }
+        }
+    }
+
+    public void checkForItemUpdates(final ViewItem item) {
+        if(!item.checkedUpdates && item.downloaded)
+        {
+            ManagedTask task = new ManagedTask() {
+                @Override
+                public void start() {
+                    Log.i(TAG, "Checking for updates on " + item.containerSlug);
+                    try {
+                        if (interrupted()) return;
+                        ResourceContainer container = App.getLibrary().open(item.containerSlug);
+                        int lastModified = App.getLibrary().getResourceContainerLastModified(container.language.slug, container.project.slug, container.resource.slug);
+                        setResult(lastModified > container.modifiedAt);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            };
+            task.addOnFinishedListener(new ManagedTask.OnFinishedListener() {
+                @Override
+                public void onTaskFinished(final ManagedTask task) {
+                    TaskManager.clearTask(task);
+                    boolean hasUpdates = false;
+                    if (task.getResult() != null) hasUpdates = (boolean) task.getResult();
+                    item.hasUpdates = hasUpdates;
+                    Log.i(TAG, "Checking for updates on " + item.containerSlug + " finished, needs updates: " + hasUpdates);
+                    item.checkedUpdates = true;
+                    item.currentTaskId = null;
+
+                    Handler hand = new Handler(Looper.getMainLooper());
+                    hand.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            notifyDataSetChanged();
+                        }
+                    });
+                }
+            });
+            item.currentTaskId = TaskManager.addTask(task);
         }
     }
 
@@ -321,11 +365,7 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
         }
 
         // load update status
-        final ViewHolder staticHolder = holder;
-        staticHolder.currentPosition = position;
-        ManagedTask oldTask = TaskManager.getTask(holder.currentTaskId);
-        TaskManager.cancelTask(oldTask);
-        TaskManager.clearTask(oldTask);
+        holder.currentPosition = position;
 
         holder.titleView.setText(item.title);
         if( (rowType == TYPE_ITEM_NEED_DOWNLOAD) || (rowType == TYPE_ITEM_SELECTABLE_UPDATABLE)) {
@@ -407,7 +447,6 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
         public TextView titleView;
         public ImageView checkboxView;
         public ImageView downloadView;
-        public Object currentTaskId;
         public int currentPosition;
     }
 
@@ -419,6 +458,7 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
         public boolean downloaded;
         public boolean hasUpdates;
         public boolean checkedUpdates = false;
+        public Object currentTaskId = null;
 
         public ViewItem(CharSequence title, Translation sourceTranslation, boolean selected, boolean downloaded) {
             this.title = title;

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationAdapter.java
@@ -67,6 +67,7 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
      * Adds an item to the list
      * If the item id matches an existing item it will be skipped
      * @param item
+     * @param selectable - true if this is to be in the selectable section
      */
     public void addItem(final ViewItem item, boolean selectable) {
         if(!mData.containsKey(item.containerSlug)) {

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationAdapter.java
@@ -96,6 +96,10 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
         }
     }
 
+    /**
+     * will check for updates for language if needed
+     * @param item
+     */
     public void checkForItemUpdates(final ViewItem item) {
         if(!item.checkedUpdates && item.downloaded)
         {
@@ -118,11 +122,15 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
                 public void onTaskFinished(final ManagedTask task) {
                     TaskManager.clearTask(task);
                     boolean hasUpdates = false;
+                    item.currentTaskId = null;
+                    if(task.isCanceled()) {
+                        Log.i(TAG, "Checking for updates on " + item.containerSlug + " cancelled");
+                        return;
+                    }
                     if (task.getResult() != null) hasUpdates = (boolean) task.getResult();
                     item.hasUpdates = hasUpdates;
                     Log.i(TAG, "Checking for updates on " + item.containerSlug + " finished, needs updates: " + hasUpdates);
                     item.checkedUpdates = true;
-                    item.currentTaskId = null;
 
                     Handler hand = new Handler(Looper.getMainLooper());
                     hand.post(new Runnable() {

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationDialog.java
@@ -149,6 +149,7 @@ public class ChooseSourceTranslationDialog extends DialogFragment implements Man
                     } else {
                         // toggle
                         mAdapter.toggleSelection(position);
+                        mAdapter.checkForItemUpdates(item);
                     }
                 }
             }
@@ -289,7 +290,7 @@ public class ChooseSourceTranslationDialog extends DialogFragment implements Man
     private void addSourceTranslation(final Translation sourceTranslation, final boolean selected) {
         final String title = sourceTranslation.language.name + " (" + sourceTranslation.language.slug + ") - " + sourceTranslation.resource.name;
         final boolean isDownloaded = mLibrary.exists(sourceTranslation.resourceContainerSlug);
-        mAdapter.addItem(new ChooseSourceTranslationAdapter.ViewItem(title, sourceTranslation, selected, isDownloaded));
+        mAdapter.addItem(new ChooseSourceTranslationAdapter.ViewItem(title, sourceTranslation, selected, isDownloaded), selected);
     }
 
     /**


### PR DESCRIPTION
Fix #1979 disable source selection while checking for updates

Changes in this pull request:
- ChooseSourceTranslationDialog - changed to show loading dialog while sources being checked.  Kicks off check for update whenever user selects a language. Made progress dialog useful for loading as well as downloading.
- ChooseSourceTranslationAdapter - changed to check the language for updates as it was being added only if selected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/1994)
<!-- Reviewable:end -->
