### PR TITLE
Fix #1638 fix SD card access verbiage

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -646,13 +646,13 @@ Attribution of artwork: All images used in these stories are © Sweet Publishing
 <![CDATA[
 Do you want to enable SD card access?  If so then:
 \n
-\n\u00A0\u00A0 1) Click \'Confirm\' at bottom of this message.
+\n\u00A0\u00A0 1) Tap \'Confirm\' at bottom of this message. This message will close and a new window will open.
 \n
-\n\u00A0\u00A0 2) If there is no SD Card icon on the left - then tap the 3-dot icon on the top right.  Tap on \'Show SD Card.\'
+\n\u00A0\u00A0 2) If you do not see the \'SD Card\' icon in the left column then tap on the 3-dot icon at the top right of the window. Then tap on \'Show SD Card.\'
 \n
-\n\u00A0\u00A0 3) If the SD Card icon is on left - then tap on the icon. Then click on the words \'Select "SD Card"\' at bottom of the window.
+\n\u00A0\u00A0 3) If the \'SD Card\' icon is in the left column then tap on the icon. The files on the SD card are then shown.  Tap on the words \'SELECT "SD Card"\' at the bottom of the window.
 \n
-\nIf you press SKIP, then import/backup will use internal memory.
+\nIf you tap on SKIP below, then Import/Backup will use internal memory.
 ]]>
     </string>
     <string name="access_title">Access Attempt</string>


### PR DESCRIPTION
Fix #1638 fix SD card access verbiage

Changes in this pull request:
- Tweaks to verbiage on instructions to enable SD Card access.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2014)
<!-- Reviewable:end -->
