### PR TITLE
Fix #1762 QA fail - change merge prompt

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/ImportUsfmActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/ImportUsfmActivity.java
@@ -310,31 +310,38 @@ public class ImportUsfmActivity extends BaseActivity implements TargetLanguageLi
 
                     if(processSuccess) { // only show continue if successful processing
                         mMergeConflict = checkForMergeConflict();
-                        if(mMergeConflict) {
+
+                        if(mMergeConflict) { // if merge conflict change the buttons and text
                             mStatusDialog.setTitle(R.string.merge_conflict_title);
                             String warning = getResources().getString(R.string.import_merge_conflict_project_name, mConflictingTargetTranslationID);
                             mStatusDialog.setMessage(message + "\n" + warning);
-                        }
 
-                        // change the buttons
-                        mStatusDialog.setPositiveButton(R.string.merge_projects_label, new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                doUsfmImport(false);
-                            }
-                        });
-                        mStatusDialog.setNeutralButton(R.string.title_cancel, new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                usfmImportDone(true);
-                            }
-                        });
-                        mStatusDialog.setNegativeButton(R.string.overwrite_projects_label, new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                doUsfmImport(true);
-                            }
-                        });
+                            mStatusDialog.setPositiveButton(R.string.merge_projects_label, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    doUsfmImport(false);
+                                }
+                            });
+                            mStatusDialog.setNeutralButton(R.string.title_cancel, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    usfmImportDone(true);
+                                }
+                            });
+                            mStatusDialog.setNegativeButton(R.string.overwrite_projects_label, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    doUsfmImport(true);
+                                }
+                            });
+                        } else { // no merge conflict
+                            mStatusDialog.setPositiveButton(R.string.label_continue, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    doUsfmImport(false);
+                                }
+                            });
+                        }
                     }
                     mStatusDialog.show();
                 }

--- a/app/src/main/java/com/door43/translationstudio/ui/home/ImportDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/ImportDialog.java
@@ -394,7 +394,7 @@ public class ImportDialog extends DialogFragment implements SimpleTaskWatcher.On
     public void showMergeConflict(String targetTranslationID) {
         mDialogShown = eDialogShown.MERGE_CONFLICT;
         mTargetTranslationID = targetTranslationID;
-        String message = getActivity().getString(R.string.import_merge_conflict_choices, targetTranslationID);
+        String message = getActivity().getString(R.string.import_merge_conflict_project_name, targetTranslationID);
         new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
                 .setTitle(R.string.merge_conflict_title)
                 .setMessage(message)

--- a/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
@@ -335,7 +335,7 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
     public void showMergeConflict(TargetTranslation targetTranslation) {
         mDialogShown = eDialogShown.MERGE_CONFLICT;
         mTargetTranslation = targetTranslation;
-        String message = getActivity().getString(R.string.import_merge_conflict_choices, targetTranslation.getId());
+        String message = getActivity().getString(R.string.import_merge_conflict_project_name, targetTranslation.getId());
         new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
                 .setTitle(R.string.merge_conflict_title)
                 .setMessage(message)

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -2329,14 +2329,27 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
 
             final boolean mergeConflictFound = mergeConflictsTask.hasMergeConflict();
             boolean doMergeFiltering = mergeConflictFound && mMergeConflictFilterEnabled;
-            final boolean conflictCountChanged = mergeConflictsTask.getConflictCount() != mFilteredItems.size();
+            final int conflictCount = mergeConflictsTask.getConflictCount();
+            final boolean conflictCountChanged = conflictCount != mFilteredItems.size();
             final boolean needToUpdateFilter = (doMergeFiltering != mMergeConflictFilterOn) || conflictCountChanged;
 
             Handler hand = new Handler(Looper.getMainLooper());
             hand.post(new Runnable() {
                 @Override
                 public void run() {
-                   filter(mSearchText, searchSubject, mSearchPosition); // update search filter
+                    if(mShowMergeSummary) {
+                        mShowMergeSummary = false; // we just show the merge summary once
+                        String message = mContext.getString(R.string.merge_summary, conflictCount);
+
+                        // pop up note prompt
+                        new AlertDialog.Builder(mContext, R.style.AppTheme_Dialog)
+                                .setTitle(R.string.change_complete_title)
+                                .setMessage(message)
+                                .setPositiveButton(R.string.label_close, null)
+                                .show();
+                    }
+
+                    filter(mSearchText, searchSubject, mSearchPosition); // update search filter
                 }
             });
 

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -2311,6 +2311,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
                 mFilteredItems = results;
                 updateMergeConflict();
                 triggerNotifyDataSetChanged();
+                checkForConflictSummary(mFilteredItems.size());
             }
         });
         filter.filter(filterConstraint);
@@ -2333,22 +2334,12 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
             final boolean conflictCountChanged = conflictCount != mFilteredItems.size();
             final boolean needToUpdateFilter = (doMergeFiltering != mMergeConflictFilterOn) || conflictCountChanged;
 
+            checkForConflictSummary(conflictCount);
+
             Handler hand = new Handler(Looper.getMainLooper());
             hand.post(new Runnable() {
                 @Override
                 public void run() {
-                    if(mShowMergeSummary) {
-                        mShowMergeSummary = false; // we just show the merge summary once
-                        String message = mContext.getString(R.string.merge_summary, conflictCount);
-
-                        // pop up note prompt
-                        new AlertDialog.Builder(mContext, R.style.AppTheme_Dialog)
-                                .setTitle(R.string.change_complete_title)
-                                .setMessage(message)
-                                .setPositiveButton(R.string.label_close, null)
-                                .show();
-                    }
-
                     filter(mSearchText, searchSubject, mSearchPosition); // update search filter
                 }
             });
@@ -2417,6 +2408,32 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
                         }
                     }
                 }
+            });
+        }
+    }
+
+    /**
+     * check if we are supposed to pop up summary
+     * @param conflictCount
+     */
+    protected void checkForConflictSummary(final int conflictCount) {
+        if(mShowMergeSummary) {
+            mShowMergeSummary = false; // we just show the merge summary once
+
+            Handler hand = new Handler(Looper.getMainLooper());
+            hand.post(new Runnable() {
+                @Override
+                public void run() {
+                    String message = mContext.getString(R.string.merge_summary, conflictCount);
+
+                    // pop up merge conflict summary
+                    new AlertDialog.Builder(mContext, R.style.AppTheme_Dialog)
+                            .setTitle(R.string.change_complete_title)
+                            .setMessage(message)
+                            .setPositiveButton(R.string.label_close, null)
+                            .show();
+                }
+
             });
         }
     }

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
@@ -271,6 +271,10 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
             mSearchString = savedInstanceState.getString(STATE_SEARCH_TEXT, null);
             mHaveMergeConflict = savedInstanceState.getBoolean(STATE_HAVE_MERGE_CONFLICT, false);
             mMergeConflictFilterEnabled = savedInstanceState.getBoolean(STATE_MERGE_CONFLICT_FILTER_ENABLED, false);
+        } else {
+            if(mFragment instanceof ViewModeFragment) {
+                ((ViewModeFragment) mFragment).setShowMergeSummary(mMergeConflictFilterEnabled);
+            }
         }
 
         setSearchBarVisibility(mSearchEnabled);

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
@@ -109,6 +109,7 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
     private boolean mSearchAtStart = false;
     private int mNumberOfChunkMatches = 0;
     private boolean mSearchResumed = false;
+    private boolean mShowConflictSummary = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -272,9 +273,7 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
             mHaveMergeConflict = savedInstanceState.getBoolean(STATE_HAVE_MERGE_CONFLICT, false);
             mMergeConflictFilterEnabled = savedInstanceState.getBoolean(STATE_MERGE_CONFLICT_FILTER_ENABLED, false);
         } else {
-            if(mFragment instanceof ViewModeFragment) {
-                ((ViewModeFragment) mFragment).setShowMergeSummary(mMergeConflictFilterEnabled);
-            }
+            mShowConflictSummary = mMergeConflictFilterEnabled;
         }
 
         setSearchBarVisibility(mSearchEnabled);
@@ -296,7 +295,9 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
             public void run() {
                 mMergeConflictFilterEnabled = enableFilter;
                 if(mFragment instanceof ViewModeFragment) {
-                    ((ViewModeFragment) mFragment).setMergeConflictFilter(enableFilter);
+                    ViewModeFragment viewModeFragment = (ViewModeFragment) TargetTranslationActivity.this.mFragment;
+                    viewModeFragment.setShowMergeSummary(mShowConflictSummary);
+                    viewModeFragment.setMergeConflictFilter(enableFilter);
                 }
                 onEnableMergeConflict(mHaveMergeConflict, mMergeConflictFilterEnabled);
             }

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeAdapter.java
@@ -32,6 +32,7 @@ public abstract class ViewModeAdapter<VH extends RecyclerView.ViewHolder> extend
     protected String startingChunkSlug;
     private int currentPosition = -1;
     private MovementDirection currentMovementDirection = MovementDirection.UNKNOWN;
+    protected boolean mShowMergeSummary = false;
 
     private enum MovementDirection {
         UP,
@@ -168,6 +169,14 @@ public abstract class ViewModeAdapter<VH extends RecyclerView.ViewHolder> extend
      * @param holder
      */
     abstract void onCoordinate(VH holder);
+
+    /**
+     * set true if we want to initially show a summary of merge conflicts
+     * @param showMergeSummary
+     */
+    public void setShowMergeSummary(boolean showMergeSummary) {
+        mShowMergeSummary = showMergeSummary;
+    }
 
     /**
      * get the chapter slug for the position

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeFragment.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeFragment.java
@@ -201,6 +201,14 @@ public abstract class ViewModeFragment extends BaseFragment implements ViewModeA
     }
 
     /**
+     * set true if we want to initially show a summary of merge conflicts
+     * @param showMergeSummary
+     */
+    public void setShowMergeSummary(boolean showMergeSummary) {
+        if(mAdapter != null) mAdapter.setShowMergeSummary(showMergeSummary);
+    }
+
+    /**
      * get the chapter slug for the position
      * @param position
      */

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeFragment.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeFragment.java
@@ -205,7 +205,9 @@ public abstract class ViewModeFragment extends BaseFragment implements ViewModeA
      * @param showMergeSummary
      */
     public void setShowMergeSummary(boolean showMergeSummary) {
-        if(mAdapter != null) mAdapter.setShowMergeSummary(showMergeSummary);
+        if(mAdapter != null) {
+            mAdapter.setShowMergeSummary(showMergeSummary);
+        }
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -878,7 +878,7 @@ Do you want to enable SD card access?  If so then:
     <string name="conflict_exists">CONFLICT EXISTS!</string>
     <string name="resolve_confict_instructions">Conflict: Click on the version to keep</string>
     <string name="merge_conflict_title">Project Already Exists</string>
-    <string name="import_merge_conflict_project_name">This project (<xliff:g example="en_ulb_reg" id="translation">%1$s</xliff:g>) already exists locally with differences in some chunks.\nHow would you like to proceed?</string>
+    <string name="import_merge_conflict_project_name">This project (<xliff:g example="en_ulb_reg" id="translation">%1$s</xliff:g>) already exists locally with differences in some chunks. How would you like to proceed?</string>
     <string name="import_merge_conflict">This project already exists locally with differences in some chunks.\nHow would you like to proceed?</string>
     <string name="label_change">change</string>
     <string name="update_languages">Update List of Available Target Languages</string>
@@ -953,7 +953,6 @@ Do you want to enable SD card access?  If so then:
     <string name="print_success">Print successfully saved to:\n<xliff:g example="/downloads/en_ulb.pdf" id="destination">%1$s</xliff:g></string>
     <string name="check_network_connection">Check your internet and try again</string>
     <string name="upload_complete">Upload Complete</string>
-    <string name="import_usfm_merge_conflict">Project <xliff:g example="en_ulb_reg" id="translation">%1$s</xliff:g> already exists\nClick Continue to merge and resolve conflicts.</string>
     <string name="unpacking">Unpacking Images</string>
     <string name="merge_projects_label">Merge Projects</string>
     <string name="overwrite_projects_label">Overwrite Project</string>
@@ -974,4 +973,6 @@ Do you want to enable SD card access?  If so then:
     <string name="reference">Reference</string>
     <string name="title_footnote">Footnote</string>
     <string name="access_not_root">Failed to enable access to SD card base.\nYou may have selected a folder other than the SD CARD base.\nMake sure you pressed the \'SD card\' icon on the left, and then that the button you pressed on the bottom said \'SELECT \"SD card\"\'.</string>
+    <string name="merge_summary">The project has been changed. There are (<xliff:g example="37" id="count">%1$d</xliff:g>) chunks that contain conflicts that need your attention.</string>
+    <string name="change_complete_title">Change Complete</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -877,8 +877,9 @@ Do you want to enable SD card access?  If so then:
     <string name="update_source_language">Do you want to update \'<xliff:g example="Pig Latin" id="language">%1$s</xliff:g>\' from Online (requires internet)?</string>
     <string name="conflict_exists">CONFLICT EXISTS!</string>
     <string name="resolve_confict_instructions">Conflict: Click on the version to keep</string>
-    <string name="merge_conflict_title">Merge Conflict</string>
-    <string name="import_merge_conflict">Merge conflict on Import - Click OK to resolve</string>
+    <string name="merge_conflict_title">Project Already Exists</string>
+    <string name="import_merge_conflict_project_name">This project (<xliff:g example="en_ulb_reg" id="translation">%1$s</xliff:g>) already exists locally with differences in some chunks.\nHow would you like to proceed?</string>
+    <string name="import_merge_conflict">This project already exists locally with differences in some chunks.\nHow would you like to proceed?</string>
     <string name="label_change">change</string>
     <string name="update_languages">Update List of Available Target Languages</string>
     <string name="update_source">Update List of Available Source Texts</string>
@@ -956,7 +957,6 @@ Do you want to enable SD card access?  If so then:
     <string name="unpacking">Unpacking Images</string>
     <string name="merge_projects_label">Merge Projects</string>
     <string name="overwrite_projects_label">Overwrite Project</string>
-    <string name="import_merge_conflict_choices">Merge conflict on Import with:\n<xliff:g example="en_ulb_reg" id="translation">%1$s</xliff:g>.\n\nClick OK to resolve merge or Click CANCEL to keep project unchanged</string>
     <string name="project_output_filename_title_prompt">Enter Project output file name:</string>
     <string name="translation_questions">Questions</string>
     <string name="translation_academy">Translation Academy</string>


### PR DESCRIPTION
Fix #1762 QA fail - change merge prompt

Changes in this pull request:
- Have merge/overwrite prompting looking closer to what was requested without doing a major rewrite.
- ImportDialog - Changed import dialog text.
- ImportUsfmActivity - Added dialog for merge/overwrite prompting.  Added support for import overwrite.
- ImportFromDoor43Dialog - Changed import dialog text.  Added progress dialog on import (after download).
- ReviewModeAdapter - Add option to show merge conflict summary. 
- TargetTranslationActivity - show merge conflict summary when merge conflict.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2030)
<!-- Reviewable:end -->
