### PR TITLE
Fix #2016 fix SD card access granted dialog

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
@@ -1,17 +1,14 @@
 package com.door43.translationstudio.ui.translate;
 
-import android.app.Activity;
 import android.app.Fragment;
 import android.app.FragmentTransaction;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Rect;
-import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.design.widget.Snackbar;
-import android.support.v7.app.AlertDialog;
 import android.text.Editable;
 import android.text.Layout;
 import android.text.TextWatcher;
@@ -1268,28 +1265,7 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
 
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == SdUtils.REQUEST_CODE_STORAGE_ACCESS) {
-            Uri treeUri = null;
-            String msg = "";
-            if (resultCode == Activity.RESULT_OK) {
-
-                // Get Uri from Storage Access Framework.
-                treeUri = data.getData();
-                final int takeFlags = data.getFlags();
-                SdUtils.WriteAccessMode status = SdUtils.validateSdCardWriteAccess(treeUri, takeFlags);
-                if (status != SdUtils.WriteAccessMode.ENABLED_CARD_BASE) {
-                    FileChooserActivity.accessErrorPrompt(this, treeUri, status);
-                    return;
-                } else {
-                    msg = getResources().getString(R.string.access_granted_backup);
-                }
-            } else {
-                msg = getResources().getString(R.string.access_skipped);
-            }
-            new AlertDialog.Builder(this, R.style.AppTheme_Dialog)
-                    .setTitle(R.string.access_title)
-                    .setMessage(msg)
-                    .setPositiveButton(R.string.label_ok, null)
-                    .show();
+            FileChooserActivity.showSdCardAccessResults(this, resultCode, data);
         } else {
             super.onActivityResult(requestCode, resultCode, data);
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -657,8 +657,7 @@ Do you want to enable SD card access?  If so then:
     </string>
     <string name="access_title">Access Attempt</string>
     <string name="access_failed">Failed on access request to:\n\'%s\'\nYou may have selected a folder other than the SD CARD base.\nMake sure you pressed the \'SD card\' icon on the left, and then that the button you pressed on the bottom said \'SELECT \"SD card\"\'.</string>
-    <string name="access_granted_backup">Success!\nAccess Granted.\nPlease retry SD CARD backup operation.</string>
-    <string name="access_granted_import">Success!\nAccess Granted.</string>
+    <string name="access_granted_sd_card">Success! Access Allowed.\n\nAfter tapping OK, choose the destination folder and then the file name for your export.</string>
     <string name="access_skipped">Access Request Cancelled</string>
     <string name="label_skip">Skip</string>
     <string name="label_internal">Internal</string>
@@ -974,4 +973,5 @@ Do you want to enable SD card access?  If so then:
     <string name="reference">Reference</string>
     <string name="title_footnote">Footnote</string>
     <string name="access_not_root">Failed to enable access to SD card base.\nYou may have selected a folder other than the SD CARD base.\nMake sure you pressed the \'SD card\' icon on the left, and then that the button you pressed on the bottom said \'SELECT \"SD card\"\'.</string>
+    <string name="access_success_title">Enable SD Card Access</string>
 </resources>


### PR DESCRIPTION
Fix #2016 fix SD card access granted dialog

Changes in this pull request:
- TargetTranslationActivity - consolidated shared SD card results dialog into FileChooserActivity.
- FileChooserActivity - added unique dialog title when SD card access is granted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2032)
<!-- Reviewable:end -->
