### PR TITLE
Fix #2027 fix crash on KitKat

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
@@ -235,8 +235,6 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
             public void onClick(View v) {
                 removeSearchBar();
                 openTranslationMode(TranslationViewMode.READ, null);
-
-                TargetTranslationActivity activity = (TargetTranslationActivity) v.getContext();
             }
         });
 
@@ -245,8 +243,6 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
             public void onClick(View v) {
                 removeSearchBar();
                 openTranslationMode(TranslationViewMode.CHUNK, null);
-
-                TargetTranslationActivity activity = (TargetTranslationActivity) v.getContext();
             }
         });
 
@@ -257,8 +253,6 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
                 mMergeConflictFilterEnabled = false;
                 setMergeConflictFilter(mMergeConflictFilterEnabled);
                 openTranslationMode(TranslationViewMode.REVIEW, null);
-
-                TargetTranslationActivity activity = (TargetTranslationActivity) v.getContext();
             }
         });
 


### PR DESCRIPTION
Fix #2027 fix crash on KitKat.  This addresses one issue found, but not the issue Kos is seeing.

Changes in this pull request:
- TargetTranslationActivity - Fix exception thrown on KitKat trying to cast context to TargetTranslationActivity. Removed dead code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2034)
<!-- Reviewable:end -->
