### PR TITLE
Fix #2037 import dialog small screen fix

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.java
@@ -306,7 +306,7 @@ public class DownloadSourcesDialog extends DialogFragment implements ManagedTask
 
     @Override
     public void onResume() {
-        super.onStart();
+        super.onResume();
 
         // widen dialog to accommodate more text
         int desiredWidth = 750;

--- a/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
@@ -6,10 +6,12 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AlertDialog;
+import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.EditText;
@@ -236,6 +238,21 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
                 Logger.e(TAG,"Unsupported restore dialog: " + mDialogShown.toString());
                 break;
         }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        // widen dialog to accommodate more text
+        int desiredWidth = 750;
+        DisplayMetrics displayMetrics = getResources().getDisplayMetrics();
+        int width = displayMetrics.widthPixels;
+        float density = displayMetrics.density;
+        float correctedWidth = width / density;
+        float screenWidthFactor = desiredWidth /correctedWidth;
+        screenWidthFactor = Math.min(screenWidthFactor, 1f); // sanity check
+        getDialog().getWindow().setLayout((int) (width * screenWidthFactor), WindowManager.LayoutParams.MATCH_PARENT);
     }
 
     @Override


### PR DESCRIPTION
Fix #2037 import dialog small screen fix

Changes in this pull request:
- ImportFromDoor43Dialog - fix for small screen sizes - maximize dialog width on small screens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2039)
<!-- Reviewable:end -->
