### PR TITLE
Fix #2051 choose sources on small screen

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationDialog.java
@@ -10,10 +10,12 @@ import android.support.design.widget.Snackbar;
 import android.support.v7.app.AlertDialog;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.EditText;
@@ -231,6 +233,21 @@ public class ChooseSourceTranslationDialog extends DialogFragment implements Man
 
         loadData();
         return v;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        // widen dialog to accommodate more text
+        int desiredWidth = 750;
+        DisplayMetrics displayMetrics = getResources().getDisplayMetrics();
+        int width = displayMetrics.widthPixels;
+        float density = displayMetrics.density;
+        float correctedWidth = width / density;
+        float screenWidthFactor = desiredWidth /correctedWidth;
+        screenWidthFactor = Math.min(screenWidthFactor, 1f); // sanity check
+        getDialog().getWindow().setLayout((int) (width * screenWidthFactor), WindowManager.LayoutParams.MATCH_PARENT);
     }
 
     private void loadData() {


### PR DESCRIPTION
Fix #2051 choose sources on small screen

Changes in this pull request:
- ChooseSourceTranslationDialog - Fix for small display.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2054)
<!-- Reviewable:end -->
