### PR TITLE
Fix #2056 wrong merge conflict mode indication on rotation

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -1858,21 +1858,22 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
      * @param showMergeConflict
      * @param mergeConflictFilterMode
      */
-    private void showMergeConflictIcon(final boolean showMergeConflict, final boolean mergeConflictFilterMode) {
-        if( (showMergeConflict != mHaveMergeConflict) || (mergeConflictFilterMode != mMergeConflictFilterEnabled) ) {
+    private void showMergeConflictIcon(final boolean showMergeConflict, boolean mergeConflictFilterMode) {
+        final boolean mergeConflictFilterEnabled = showMergeConflict ? mergeConflictFilterMode : false;
+        if( (showMergeConflict != mHaveMergeConflict) || (mergeConflictFilterEnabled != mMergeConflictFilterEnabled) ) {
             Handler hand = new Handler(Looper.getMainLooper());
             hand.post(new Runnable() {
                 @Override
                 public void run() {
                     OnEventListener listener = getListener();
                     if(listener != null) {
-                        listener.onEnableMergeConflict(showMergeConflict, mergeConflictFilterMode);
+                        listener.onEnableMergeConflict(showMergeConflict, mergeConflictFilterEnabled);
                     }
                 }
             });
         }
         mHaveMergeConflict = showMergeConflict;
-        mMergeConflictFilterEnabled = mHaveMergeConflict ? mergeConflictFilterMode : false;
+        mMergeConflictFilterEnabled = mergeConflictFilterEnabled;
     }
 
     /**
@@ -2285,9 +2286,9 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
      */
     @Override
     public final void setMergeConflictFilter(boolean enableFilter) {
-        mMergeConflictFilterEnabled = enableFilter;
+        showMergeConflictIcon(mHaveMergeConflict, enableFilter); // update display and status flags
 
-        if(!mHaveMergeConflict || !mMergeConflictFilterEnabled) { // if no merge conflict or filter off, then remove filter
+        if(!mHaveMergeConflict || !enableFilter) { // if no merge conflict or filter off, then remove filter
             mFilteredItems = mItems;
             mFilteredChapters = mChapters;
 

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
@@ -185,8 +185,6 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
         mFoundText = (TextView) findViewById(R.id.found);
         mFoundTextFormat = R.string.found_in_chunks;
 
-        setupSidebarModeIcons();
-
         // inject fragments
         if (findViewById(R.id.fragment_container) != null) {
             if (savedInstanceState != null) {
@@ -267,6 +265,7 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
             mShowConflictSummary = mMergeConflictFilterEnabled;
         }
 
+        setupSidebarModeIcons();
         setSearchBarVisibility(mSearchEnabled);
         if(mSearchEnabled) {
             setSearchSpinner(true, mNumberOfChunkMatches, mSearchAtEnd, mSearchAtStart); // restore initial state
@@ -1254,6 +1253,7 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
             case REVIEW:
                 if(mMergeConflictFilterEnabled) {
                     mMergeConflict.setBackgroundColor(highlightedColor); // highlight background of the conflict icon
+                    onEnableMergeConflict(true, true);
                 } else {
                     mReviewButton.setBackgroundColor(highlightedColor);
                     mReviewButton.setImageResource(R.drawable.ic_view_week_white_24dp);


### PR DESCRIPTION
Fix #2056 wrong merge conflict mode indication on rotation

Changes in this pull request:
- TargetTranslationActivity - Fix to restore merge conflict mode on rotation.
- ReviewModeAdapter - Fix to keep merge conflict icons and internal flags in sync.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2061)
<!-- Reviewable:end -->
