### PR TITLE
Fix #2021 problems with rotating device while downloading sources

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -975,4 +975,5 @@ Do you want to enable SD card access?  If so then:
     <string name="merge_summary">The projects have been merged. There are (<xliff:g example="37" id="count">%1$d</xliff:g>) chunks that contain conflicts that need your attention.</string>
     <string name="merge_complete_title">Merge Complete</string>
     <string name="access_success_title">Enable SD Card Access</string>
+    <string name="interrupting_download">Trying to interrupt download</string>
 </resources>


### PR DESCRIPTION
Fix #2021 problems with rotating device while downloading sources

Changes in this pull request:
- DownloadSourcesDialog - removed cancel button when loading the initial sources list - this caused a lot of trouble if the user did this.  For download progress, changed cancel button to not auto dismiss dialog, and added a message that we are cancelling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2068)
<!-- Reviewable:end -->
