### PR TITLE
Fix #2074 no search text with keyboard

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/App.java
+++ b/app/src/main/java/com/door43/translationstudio/App.java
@@ -982,6 +982,21 @@ public class App extends Application {
     }
 
     /**
+     * Closes the keyboard for view that has focus, need to use this in dialog fragments
+     * @param context
+     * @param view - value that has focus (usually EditText)
+     */
+    public static void closeKeyboard(Context context, View view) {
+        if((view != null) && (context != null)) {
+            try {
+                InputMethodManager imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+                imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+            } catch (Exception e) {
+            }
+        }
+    }
+
+    /**
      * Returns the string value of a user preference or the default value
      * @param preferenceKey
      * @param defaultValue

--- a/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
@@ -109,7 +109,12 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
                 String userQuery = userEditText.getText().toString();
                 String repoQuery = repoEditText.getText().toString();
 
-                App.closeKeyboard(getActivity()); // this doesn't seem to work here
+                if (userEditText.hasFocus()) {
+                    App.closeKeyboard(getActivity(), userEditText);
+                }
+                if (repoEditText.hasFocus()) {
+                    App.closeKeyboard(getActivity(), repoEditText);
+                }
 
                 Profile profile = App.getProfile();
                 if(profile != null && profile.gogsUser != null) {


### PR DESCRIPTION
Fix #2074 no search text with keyboard

Changes in this pull request:
- ImportFromDoor43Dialog - fixed closing keyboard from within dialog fragment since activity.getCurrentFocus() does not work within a fragment.
- App - added new closeKeyboard that works on view

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2075)
<!-- Reviewable:end -->
