### PR TITLE
Fix #2078 need 2 clicks on merge conflict

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -2283,9 +2283,13 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
     /**
      * enable/disable merge conflict filter in adapter
      * @param enableFilter
+     * @param forceMergeConflict - if true, then will initialize have merge conflict flag to true
      */
     @Override
-    public final void setMergeConflictFilter(boolean enableFilter) {
+    public final void setMergeConflictFilter(boolean enableFilter, boolean forceMergeConflict) {
+        if(forceMergeConflict) {
+            mHaveMergeConflict = true;
+        }
         showMergeConflictIcon(mHaveMergeConflict, enableFilter); // update display and status flags
 
         if(!mHaveMergeConflict || !enableFilter) { // if no merge conflict or filter off, then remove filter
@@ -2357,7 +2361,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
                 public void run() {
                     showMergeConflictIcon(mergeConflictFound, mMergeConflictFilterEnabled);
                     if (needToUpdateFilter) {
-                        setMergeConflictFilter(mMergeConflictFilterEnabled);
+                        setMergeConflictFilter(mMergeConflictFilterEnabled, false);
                     }
                 }
             });

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -2283,12 +2283,12 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
     /**
      * enable/disable merge conflict filter in adapter
      * @param enableFilter
-     * @param forceMergeConflict - if true, then will initialize have merge conflict flag to true
+     * @param forceMergeConflict - if true, then will initialize merge conflict flag to true
      */
     @Override
     public final void setMergeConflictFilter(boolean enableFilter, boolean forceMergeConflict) {
         if(forceMergeConflict) {
-            mHaveMergeConflict = true;
+            mHaveMergeConflict = true; // initialize merge conflict flag to true
         }
         showMergeConflictIcon(mHaveMergeConflict, enableFilter); // update display and status flags
 

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
@@ -222,7 +222,7 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
                 if(mMergeConflictFilterEnabled) { // if we are turning on filter, we also need to be in review mode
                     openTranslationMode(TranslationViewMode.REVIEW, null);
                 }
-                setMergeConflictFilter(mMergeConflictFilterEnabled); // update displayed state
+                setMergeConflictFilter(mMergeConflictFilterEnabled, true); // update displayed state
             }
         });
 
@@ -247,7 +247,7 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
             public void onClick(View v) {
                 removeSearchBar();
                 mMergeConflictFilterEnabled = false;
-                setMergeConflictFilter(mMergeConflictFilterEnabled);
+                setMergeConflictFilter(mMergeConflictFilterEnabled, false);
                 openTranslationMode(TranslationViewMode.REVIEW, null);
             }
         });
@@ -277,8 +277,9 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
     /**
      * enable/disable merge conflict filter in adapter
      * @param enableFilter
+     * @param forceMergeConflict - if true, then will initialize have merge conflict flag to true
      */
-    private void setMergeConflictFilter(final boolean enableFilter) {
+    private void setMergeConflictFilter(final boolean enableFilter, final boolean forceMergeConflict) {
         Handler hand = new Handler(Looper.getMainLooper());
         hand.post(new Runnable() {
             @Override
@@ -287,7 +288,7 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
                 if(mFragment instanceof ViewModeFragment) {
                     ViewModeFragment viewModeFragment = (ViewModeFragment) TargetTranslationActivity.this.mFragment;
                     viewModeFragment.setShowMergeSummary(mShowConflictSummary);
-                    viewModeFragment.setMergeConflictFilter(enableFilter);
+                    viewModeFragment.setMergeConflictFilter(enableFilter, forceMergeConflict);
                 }
                 onEnableMergeConflict(mHaveMergeConflict, mMergeConflictFilterEnabled);
             }
@@ -827,7 +828,7 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
         super.onResume();
         notifyDatasetChanged();
         buildMenu();
-        setMergeConflictFilter(mMergeConflictFilterEnabled); // restore last state
+        setMergeConflictFilter(mMergeConflictFilterEnabled, mMergeConflictFilterEnabled); // restore last state
     }
 
     public void closeKeyboard() {

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
@@ -219,10 +219,8 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
             @Override
             public void onClick(View v) {
                 mMergeConflictFilterEnabled = !mMergeConflictFilterEnabled; // toggle filter state
-                if(mMergeConflictFilterEnabled) { // if we are turning on filter, we also need to be in review mode
-                    openTranslationMode(TranslationViewMode.REVIEW, null);
-                }
-                setMergeConflictFilter(mMergeConflictFilterEnabled, true); // update displayed state
+                openTranslationMode(TranslationViewMode.REVIEW, null); // make sure we are in review mode
+                setMergeConflictFilter(mMergeConflictFilterEnabled, mMergeConflictFilterEnabled); // update displayed state
             }
         });
 

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeAdapter.java
@@ -276,8 +276,9 @@ public abstract class ViewModeAdapter<VH extends RecyclerView.ViewHolder> extend
     /**
      * enable/disable merge conflict filter in adapter
      * @param enableFilter
+     * @param forceMergeConflict - if true, then will initialize have merge conflict flag to true
      */
-    public void setMergeConflictFilter(boolean enableFilter) {
+    public void setMergeConflictFilter(boolean enableFilter, boolean forceMergeConflict) {
         // Override this in your adapter to enable merge conflict filtering
     }
 

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeFragment.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeFragment.java
@@ -436,10 +436,11 @@ public abstract class ViewModeFragment extends BaseFragment implements ViewModeA
     /**
      * enable/disable merge conflict filter in adapter
      * @param enableFilter
+     * @param forceMergeConflict - if true, then will initialize have merge conflict flag to true
      */
-    public final void setMergeConflictFilter(boolean enableFilter) {
+    public final void setMergeConflictFilter(boolean enableFilter, boolean forceMergeConflict) {
         if(getAdapter() != null) {
-            getAdapter().setMergeConflictFilter(enableFilter);
+            getAdapter().setMergeConflictFilter(enableFilter, forceMergeConflict);
             getAdapter().triggerNotifyDataSetChanged();
         }
     }


### PR DESCRIPTION
Fix #2078 need 2 clicks on merge conflict

Changes in this pull request:
- TargetTranslationActivity, ReviewModeAdapter, etc. - fix to make sure we properly initialize the merge conflicts flag when switching from read and chunked modes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2081)
<!-- Reviewable:end -->
