### PR TITLE
Fix #2121 merge conflict count always shows 0

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -131,6 +131,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
     private boolean mAtSearchStart = true;
     private int mStringSearchTaskID = -1;
     private HashSet<Integer> visiblePositions = new HashSet<>();
+    private boolean mMergeConflictSummaryDisplayed = false;
 
     @Override
     public void onNoteClick(TranslationHelp note, int resourceCardWidth) {
@@ -2447,7 +2448,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
      * @param conflictCount
      */
     protected void checkForConflictSummary(final int conflictCount) {
-        if(mShowMergeSummary) {
+        if(mShowMergeSummary && (mItems.size() > 0)) { // wait till after items have been loaded
             mShowMergeSummary = false; // we just show the merge summary once
 
             Handler hand = new Handler(Looper.getMainLooper());
@@ -2455,16 +2456,31 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
                 @Override
                 public void run() {
                     String message = mContext.getString(R.string.merge_summary, conflictCount);
+                    mMergeConflictSummaryDisplayed = true;
 
                     // pop up merge conflict summary
                     new AlertDialog.Builder(mContext, R.style.AppTheme_Dialog)
                             .setTitle(R.string.merge_complete_title)
                             .setMessage(message)
-                            .setPositiveButton(R.string.label_close, null)
+                            .setPositiveButton(R.string.label_close, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    mMergeConflictSummaryDisplayed = false;
+                                }
+                            })
                             .show();
                 }
 
             });
         }
+    }
+
+    /**
+     * returns true if merge conflict summary dialog is being displayed.
+     * @return
+     */
+    @Override
+    public boolean ismMergeConflictSummaryDisplayed() {
+        return mMergeConflictSummaryDisplayed;
     }
 }

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
@@ -69,11 +69,12 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
     public static final String STATE_SEARCH_TEXT = "state_search_text";
     public static final String STATE_HAVE_MERGE_CONFLICT = "state_have_merge_conflict";
     public static final String STATE_MERGE_CONFLICT_FILTER_ENABLED = "state_merge_conflict_filter_enabled";
-    public static final int RESULT_DO_UPDATE = 42;
+    public static final String STATE_MERGE_CONFLICT_SUMMARY_DISPLAYED = "state_merge_conflict_summary_displayed";
     public static final String SEARCH_SOURCE = "search_source";
     public static final String STATE_SEARCH_AT_END = "state_search_at_end";
     public static final String STATE_SEARCH_AT_START = "state_search_at_start";
     public static final String STATE_SEARCH_FOUND_CHUNKS = "state_search_found_chunks";
+    public static final int RESULT_DO_UPDATE = 42;
     private Fragment mFragment;
     private SeekBar mSeekBar;
     private ViewGroup mGraduations;
@@ -259,6 +260,7 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
             mSearchString = savedInstanceState.getString(STATE_SEARCH_TEXT, null);
             mHaveMergeConflict = savedInstanceState.getBoolean(STATE_HAVE_MERGE_CONFLICT, false);
             mMergeConflictFilterEnabled = savedInstanceState.getBoolean(STATE_MERGE_CONFLICT_FILTER_ENABLED, false);
+            mShowConflictSummary = savedInstanceState.getBoolean(STATE_MERGE_CONFLICT_SUMMARY_DISPLAYED, false);
         } else {
             mShowConflictSummary = mMergeConflictFilterEnabled;
         }
@@ -425,6 +427,9 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
         }
         out.putBoolean(STATE_HAVE_MERGE_CONFLICT, mHaveMergeConflict);
         out.putBoolean(STATE_MERGE_CONFLICT_FILTER_ENABLED, mMergeConflictFilterEnabled);
+        if(mFragment instanceof ViewModeFragment) {
+            out.putBoolean(STATE_MERGE_CONFLICT_SUMMARY_DISPLAYED, ((ViewModeFragment) mFragment).ismMergeConflictSummaryDisplayed());
+        }
         super.onSaveInstanceState(out);
     }
 

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeAdapter.java
@@ -414,6 +414,15 @@ public abstract class ViewModeAdapter<VH extends RecyclerView.ViewHolder> extend
         }
     }
 
+    /**
+     * returns true if merge conflict summary dialog is being displayed.  Override in adapters that
+     *      support this.
+     * @return
+     */
+    public boolean ismMergeConflictSummaryDisplayed() {
+        return false;
+    }
+
     public interface OnEventListener {
         void onSourceTranslationTabClick(String sourceTranslationId);
         void onNewSourceTranslationTabClick();

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeFragment.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeFragment.java
@@ -476,6 +476,18 @@ public abstract class ViewModeFragment extends BaseFragment implements ViewModeA
     }
 
     /**
+     * returns true if merge conflict summary dialog is being displayed.  Override in adapters that
+     *      support this.
+     * @return
+     */
+    public boolean ismMergeConflictSummaryDisplayed() {
+        if(getAdapter() != null) {
+            return getAdapter().ismMergeConflictSummaryDisplayed();
+        }
+        return false;
+    }
+
+    /**
      * Forces the software keyboard to close
      */
     public void closeKeyboard() {


### PR DESCRIPTION
Fix #2121 merge conflict count always shows 0

Changes in this pull request:
- ReviewModeAdapter - Fixed race condition that was showing merge conflict summary before items were loaded.
- TargetTranslationActivity - save and restore display state of merge conflict summary on rotation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2140)
<!-- Reviewable:end -->
