### PR TITLE
Fix #2121 QA fail merge results keeps popping up

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -2468,6 +2468,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
                                     mMergeConflictSummaryDisplayed = false;
                                 }
                             })
+                            .setCancelable(false)
                             .show();
                 }
 

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
@@ -838,7 +838,9 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
     public void onPause() {
         super.onPause();
 
-        mShowConflictSummary = ((ViewModeFragment) mFragment).ismMergeConflictSummaryDisplayed(); // update current state
+        if(mFragment instanceof ViewModeFragment) {
+            mShowConflictSummary = ((ViewModeFragment) mFragment).ismMergeConflictSummaryDisplayed(); // update current state
+        }
     }
 
     public void closeKeyboard() {

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/TargetTranslationActivity.java
@@ -834,6 +834,13 @@ public class TargetTranslationActivity extends BaseActivity implements ViewModeF
         setMergeConflictFilter(mMergeConflictFilterEnabled, mMergeConflictFilterEnabled); // restore last state
     }
 
+    @Override
+    public void onPause() {
+        super.onPause();
+
+        mShowConflictSummary = ((ViewModeFragment) mFragment).ismMergeConflictSummaryDisplayed(); // update current state
+    }
+
     public void closeKeyboard() {
         if (mFragment instanceof ViewModeFragment) {
             boolean enteringSearchText = mSearchEnabled && (mSearchEditText != null) && (mSearchEditText.hasFocus());


### PR DESCRIPTION
Fix #2121 QA fail merge results keeps popping up

Changes in this pull request:
- TargetTranslationActivity - onPause() update display state of merge conflict summary.  Prevents a cancelled merge conflict summary from popping up after file selection activity runs.
- ReviewModeAdapter - disabled cancelable on merge conflict summary dialog so display state will get updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2145)
<!-- Reviewable:end -->
