### PR TITLE
Fix #2169 RTL printing of references

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
+++ b/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
@@ -341,7 +341,7 @@ public class PdfPrinter extends PdfPageEventHelper {
                             File imageFile = new File(imagesDir, targetTranslation.getProjectId() + "-" + f.getComplexId() + ".jpg");
                             if(imageFile.exists()) {
                                 if( i != 0) {
-                                    addBidiTextToTable(10, " ", subFont, table); // add space between text and image
+                                    addBidiTextToTable(10, " ", subFont, table); // add space between text above and image below
                                 }
                                 addImage(document, table, imageFile.getAbsolutePath());
                             }
@@ -384,12 +384,10 @@ public class PdfPrinter extends PdfPageEventHelper {
             chunk.setFont(superScriptFont);
             chunk.setTextRise(5f);
             if (verse != null) {
-                String verseMarker = verse.getHumanReadable().toString();
-                chunk.append(verseMarker);
+                chunk.append(verse.getHumanReadable().toString());
             } else {
                 // failed to parse the verse
-                String verseMarker = usfm.subSequence(lastIndex, matcher.end()).toString();
-                chunk.append(verseMarker);
+                chunk.append(usfm.subSequence(lastIndex, matcher.end()).toString());
             }
             chunk.append(" ");
             paragraph.add(chunk);


### PR DESCRIPTION
Fix #2169 RTL printing of references

Changes in this pull request:
- PdfPrinter - shrunk chapter titles in TOC.  Shifted down page numbers… in TOC.  Added space between text and image below it.  Fixed RTL printing of reference and location of it.  Made verse markers superscript again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2170)
<!-- Reviewable:end -->
