### PR TITLE
Fix #2171 print dialog with long titles

### DIFF
--- a/app/src/main/res/layout/dialog_print.xml
+++ b/app/src/main/res/layout/dialog_print.xml
@@ -24,10 +24,14 @@
             android:id="@+id/project_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="@dimen/title"
             android:layout_marginBottom="@dimen/dialog_content_margin"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:minLines="1"
+            android:singleLine="true"
+            android:text="Open Bible Stories - Afaraf"
             android:textColor="@color/dark_primary_text"
-            android:text="Open Bible Stories - Afaraf"/>
+            android:textSize="@dimen/title" />
 
         <CheckBox
             android:layout_width="wrap_content"


### PR DESCRIPTION
Fix #2171 print dialog with long titles

Changes in this pull request:
- Fix problem with title wrapping on print dialog pushing options off screen.  Add Ellipsis if over long.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2172)
<!-- Reviewable:end -->
