### PR TITLE
Fix #2162 info dialog small screens

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/PrintDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/PrintDialog.java
@@ -11,10 +11,12 @@ import android.os.Handler;
 import android.os.Looper;
 import android.support.v4.provider.DocumentFile;
 import android.support.v7.app.AlertDialog;
+import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
@@ -223,6 +225,21 @@ public class PrintDialog extends DialogFragment implements SimpleTaskWatcher.OnF
                 }
             }
         });
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        // widen dialog to accommodate more text
+        int desiredWidth = 750;
+        DisplayMetrics displayMetrics = getResources().getDisplayMetrics();
+        int width = displayMetrics.widthPixels;
+        float density = displayMetrics.density;
+        float correctedWidth = width / density;
+        float screenWidthFactor = desiredWidth /correctedWidth;
+        screenWidthFactor = Math.min(screenWidthFactor, 1f); // sanity check
+        getDialog().getWindow().setLayout((int) (width * screenWidthFactor), WindowManager.LayoutParams.WRAP_CONTENT);
     }
 
     /**

--- a/app/src/main/java/com/door43/translationstudio/ui/home/TargetTranslationInfoDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/TargetTranslationInfoDialog.java
@@ -11,10 +11,12 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.v7.app.AlertDialog;
+import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.view.WindowManager;
 import android.widget.ImageButton;
 import android.widget.TextView;
 
@@ -241,6 +243,21 @@ public class TargetTranslationInfoDialog extends DialogFragment implements Manag
         // TODO: re-connect to dialogs
 
         return v;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        // widen dialog to accommodate more text
+        int desiredWidth = 600;
+        DisplayMetrics displayMetrics = getResources().getDisplayMetrics();
+        int width = displayMetrics.widthPixels;
+        float density = displayMetrics.density;
+        float correctedWidth = width / density;
+        float screenWidthFactor = desiredWidth /correctedWidth;
+        screenWidthFactor = Math.min(screenWidthFactor, 1f); // sanity check
+        getDialog().getWindow().setLayout((int) (width * screenWidthFactor), WindowManager.LayoutParams.MATCH_PARENT);
     }
 
     /**

--- a/app/src/main/res/layout/dialog_target_translation_info.xml
+++ b/app/src/main/res/layout/dialog_target_translation_info.xml
@@ -55,33 +55,39 @@
 
                 <LinearLayout
                     android:orientation="horizontal"
-                    android:layout_width="match_parent"
+                    android:layout_width="wrap_content"
                     android:paddingTop="@dimen/dialog_controls_margin"
                     android:paddingBottom="@dimen/dialog_controls_margin"
                     android:layout_height="wrap_content">
+
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:textColor="@color/dark_secondary_text"
-                        android:textSize="@dimen/body"
+                        android:layout_weight="0"
+                        android:paddingRight="10dp"
                         android:text="@string/target_language"
-                        android:paddingRight="10dp"/>
+                        android:textColor="@color/dark_secondary_text"
+                        android:textSize="@dimen/body" />
+
                     <TextView
                         android:id="@+id/language_title"
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="This is a very long language string the should not push change off screen"
                         android:textColor="@color/dark_primary_text"
-                        android:textSize="@dimen/body"
-                        android:text="Afaraf (aa)"/>
+                        android:textSize="@dimen/body" />
+
                     <TextView
                         android:id="@+id/change_language"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:textColor="@color/accent_dark"
-                        android:textSize="@dimen/body"
-                        android:text="@string/label_change"
                         android:layout_marginLeft="@dimen/dialog_content_margin"
-                        android:clickable="true" />
+                        android:layout_weight="0"
+                        android:clickable="true"
+                        android:text="@string/label_change"
+                        android:textColor="@color/accent_dark"
+                        android:textSize="@dimen/body" />
 
                 </LinearLayout>
 


### PR DESCRIPTION
Fix #2162 info dialog small screens

Changes in this pull request:
- TargetTranslationInfoDialog - fix screen width on small screens.
- dialog_target_translation_info.xml - fix problem that long language names push change button off screen.
- PrintDialog - fix screen width on small screens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2175)
<!-- Reviewable:end -->
