### PR TITLE
Fix #2180 make pdf font size track screen size selected

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
+++ b/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
@@ -39,6 +39,7 @@ import java.util.regex.Pattern;
 public class PdfPrinter extends PdfPageEventHelper {
     private static final float VERTICAL_PADDING = 72.0f; // 1 inch
     private static final float HORIZONTAL_PADDING = 72.0f; // 1 inch
+    public static final float RATIO_OF_SP_TO_PT = 2.5f;
     private final TargetTranslation targetTranslation;
     private final Context context;
     private final Font titleFont;
@@ -65,11 +66,11 @@ public class PdfPrinter extends PdfPageEventHelper {
     private PdfWriter writer;
     private Paragraph mCurrentParagraph;
     private final PrintPDFTask task;
-
+    private final float targetLanguageFontSize;
 
     public PdfPrinter(Context context, Door43Client library, TargetTranslation targetTranslation, TranslationFormat format,
-                      String targetLanguageFontPath, boolean targetlanguageRtl, String licenseFontPath,
-                      File imagesDir, PrintPDFTask task) throws IOException, DocumentException {
+                      String targetLanguageFontPath, float targetLanguageFontSize, boolean targetlanguageRtl,
+                      String licenseFontPath, File imagesDir, PrintPDFTask task) throws IOException, DocumentException {
         this.targetTranslation = targetTranslation;
         this.context = context;
         this.format = format;
@@ -85,22 +86,25 @@ public class PdfPrinter extends PdfPageEventHelper {
         }
         this.sourceContainer = rc;
 
+        targetLanguageFontSize = targetLanguageFontSize / RATIO_OF_SP_TO_PT;
+        this.targetLanguageFontSize = targetLanguageFontSize;
+
         baseFont = BaseFont.createFont(targetLanguageFontPath, BaseFont.IDENTITY_H, BaseFont.EMBEDDED);
-        titleFont = new Font(baseFont, 25, Font.BOLD);
-        chapterFont = new Font(baseFont, 20);
-        bodyFont = new Font(baseFont, 10);
-        boldBodyFont = new Font(baseFont, 10, Font.BOLD);
-        headingFont = new Font(baseFont, 14, Font.BOLD);
-        underlineBodyFont = new Font(baseFont, 10, Font.UNDERLINE);
-        subFont = new Font(baseFont, 10, Font.ITALIC);
-        superScriptFont = new Font(baseFont, 9);
+        titleFont = new Font(baseFont, targetLanguageFontSize * 2.5f, Font.BOLD);
+        chapterFont = new Font(baseFont, targetLanguageFontSize * 2);
+        bodyFont = new Font(baseFont, targetLanguageFontSize);
+        boldBodyFont = new Font(baseFont, targetLanguageFontSize, Font.BOLD);
+        headingFont = new Font(baseFont, targetLanguageFontSize * 1.4f, Font.BOLD);
+        underlineBodyFont = new Font(baseFont, targetLanguageFontSize, Font.UNDERLINE);
+        subFont = new Font(baseFont, targetLanguageFontSize, Font.ITALIC);
+        superScriptFont = new Font(baseFont, targetLanguageFontSize * 0.9f);
         superScriptFont.setColor(94, 94, 94);
 
         licenseBaseFont = BaseFont.createFont(licenseFontPath, BaseFont.IDENTITY_H, BaseFont.EMBEDDED);
         licenseFont = new Font(licenseBaseFont, 20);
         this.targetlanguageRtl = targetlanguageRtl;
         this.task = task;
-    }
+   }
 
     /**
      * Include media (images) in the pdf
@@ -373,7 +377,7 @@ public class PdfPrinter extends PdfPageEventHelper {
         Pattern pattern = Pattern.compile(USFMVerseSpan.PATTERN);
         Matcher matcher = pattern.matcher(usfm);
         int lastIndex = 0;
-        Paragraph paragraph = new Paragraph(16, "", bodyFont);
+        Paragraph paragraph = new Paragraph(targetLanguageFontSize * 1.6f, "", bodyFont);
         while(matcher.find()) {
             // add preceding text
             paragraph.add(usfm.substring(lastIndex, matcher.start()));
@@ -382,7 +386,7 @@ public class PdfPrinter extends PdfPageEventHelper {
             Span verse = new USFMVerseSpan(matcher.group(1));
             Chunk chunk = new Chunk();
             chunk.setFont(superScriptFont);
-            chunk.setTextRise(5f);
+            chunk.setTextRise(targetLanguageFontSize/2);
             if (verse != null) {
                 chunk.append(verse.getHumanReadable().toString());
             } else {

--- a/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
+++ b/app/src/main/java/com/door43/translationstudio/core/PdfPrinter.java
@@ -165,7 +165,7 @@ public class PdfPrinter extends PdfPageEventHelper {
 
                 // put in chapter title in cell
                 PdfPCell titleCell = new PdfPCell();
-                Paragraph element = new Paragraph();
+                Paragraph element = new Paragraph(targetLanguageFontSize * 1.6f); // set leading
                 element.setAlignment(Element.ALIGN_LEFT);
                 element.add(chunk);
                 titleCell.addElement(element);
@@ -184,7 +184,8 @@ public class PdfPrinter extends PdfPageEventHelper {
                     public void draw(final PdfContentByte canvas, final float llx, final float lly, final float urx, final float ury, final float y) {
                         final PdfTemplate createTemplate = canvas.createTemplate(50, 50);
                         tocPlaceholder.put(title, createTemplate);
-                        canvas.addTemplate(createTemplate, urx - 50, y - 15);
+                        float shift = targetLanguageFontSize * 1.25f;
+                        canvas.addTemplate(createTemplate, urx - 50, y - shift);
                     }
                 });
 

--- a/app/src/main/java/com/door43/translationstudio/core/Translator.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Translator.java
@@ -518,13 +518,13 @@ public class Translator {
      * @param outputFile
      */
     public void exportPdf(Door43Client library, TargetTranslation targetTranslation, TranslationFormat format,
-                          String targetLanguageFontPath, String licenseFontPath, File imagesDir,
-                          boolean includeImages, boolean includeIncompleteFrames, File outputFile,
-                          PrintPDFTask task) throws Exception {
+                          String targetLanguageFontPath, float targetLanguageFontSize, String licenseFontPath,
+                          File imagesDir, boolean includeImages, boolean includeIncompleteFrames,
+                          File outputFile, PrintPDFTask task) throws Exception {
 
         boolean targetlanguageRtl = "rtl".equals(targetTranslation.getTargetLanguageDirection());
         PdfPrinter printer = new PdfPrinter(mContext, library, targetTranslation, format, targetLanguageFontPath,
-                                                targetlanguageRtl, licenseFontPath, imagesDir, task);
+                                    targetLanguageFontSize, targetlanguageRtl, licenseFontPath, imagesDir, task);
         printer.includeMedia(includeImages);
         printer.includeIncomplete(includeIncompleteFrames);
         File pdf = printer.print();

--- a/app/src/main/java/com/door43/translationstudio/tasks/PrintPDFTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/PrintPDFTask.java
@@ -51,9 +51,12 @@ public class PrintPDFTask extends ManagedTask {
                 Project p = App.getLibrary().index().getProject("en", mTargetTranslation.getProjectId(), true);
                 List<Resource> resources = App.getLibrary().index().getResources(p.languageSlug, p.slug);
                 String targetLanguageFontPath = Typography.getAssetPath(App.context(), TranslationType.TARGET);
+                float targetLanguageFontSize = Typography.getFontSize(App.context(), TranslationType.TARGET);
                 String licenseFontName = App.context().getString(R.string.pref_default_translation_typeface);
                 String licenseFontPath = "assets/fonts/" + licenseFontName;
-                translator.exportPdf(library, mTargetTranslation, mTargetTranslation.getFormat(), targetLanguageFontPath, licenseFontPath, imagesDir, includeImages, includeIncompleteFrames, mDestFile, this);
+                translator.exportPdf(library, mTargetTranslation, mTargetTranslation.getFormat(), targetLanguageFontPath,
+                                        targetLanguageFontSize, licenseFontPath, imagesDir, includeImages,
+                                        includeIncompleteFrames, mDestFile, this);
                 if (mDestFile.exists()) {
                     success = true;
                 } else {


### PR DESCRIPTION
Fix #2180 make pdf font size track screen size selected

Changes in this pull request:
- PdfPrinter, Translator, PrintPDFTask - add target font size parameter for printing.
- PdfPrinter - Make font sizes proportional to selected target font size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2203)
<!-- Reviewable:end -->
