### PR TITLE
Fix #2188 prompt before merge on import even if there is no merge conflict.

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/core/Translator.java
+++ b/app/src/main/java/com/door43/translationstudio/core/Translator.java
@@ -443,6 +443,7 @@ public class Translator {
         File archiveDir = new File(getLocalCacheDir(), System.currentTimeMillis()+"");
         String importedSlug = null;
         boolean mergeConflict = false;
+        boolean alreadyExists = false;
         try {
             archiveDir.mkdirs();
             Zip.unzipFromStream(in, archiveDir);
@@ -455,7 +456,8 @@ public class Translator {
                     String targetTranslationId = newTargetTranslation.getId();
                     File localDir = new File(mRootDir, targetTranslationId);
                     TargetTranslation localTargetTranslation = TargetTranslation.open(localDir);
-                    if((localTargetTranslation != null) && !overwrite) {
+                    alreadyExists = localTargetTranslation != null;
+                    if(alreadyExists && !overwrite) {
                         // commit local changes to history
                         if(localTargetTranslation != null) {
                             localTargetTranslation.commitSync();
@@ -489,7 +491,7 @@ public class Translator {
             FileUtilities.deleteQuietly(archiveDir);
         }
 
-        return new ImportResults(importedSlug, mergeConflict);
+        return new ImportResults(importedSlug, mergeConflict, alreadyExists);
     }
 
     /**
@@ -500,10 +502,12 @@ public class Translator {
     public class ImportResults {
         public final String importedSlug;
         public final boolean mergeConflict;
+        public final boolean alreadyExists;
 
-        ImportResults(String importedSlug, boolean mergeConflict) {
+        ImportResults(String importedSlug, boolean mergeConflict, boolean alreadyExists) {
             this.importedSlug = importedSlug;
             this.mergeConflict = mergeConflict;
+            this.alreadyExists = alreadyExists;
         }
 
         public boolean isSuccess() {

--- a/app/src/main/java/com/door43/translationstudio/tasks/ImportProjectFromUriTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/ImportProjectFromUriTask.java
@@ -27,17 +27,20 @@ public class ImportProjectFromUriTask extends ManagedTask {
     public static final String TAG = ImportProjectFromUriTask.class.getSimpleName();
     final private Uri path;
     final private boolean mergeOverwrite;
+    private boolean alreadyExists;
 
     public ImportProjectFromUriTask(Uri path, boolean mergeOverwrite) {
         setThreadPriority(Process.THREAD_PRIORITY_DEFAULT);
         this.path = path;
         this.mergeOverwrite = mergeOverwrite;
+        alreadyExists = false;
     }
 
     @Override
     public void start() {
         boolean success = false;
         boolean mergeConflict = false;
+        alreadyExists = false;
         BufferedInputStream in = null;
         String readablePath = path.toString(); // default
         String importedSlug = "";
@@ -54,6 +57,7 @@ public class ImportProjectFromUriTask extends ManagedTask {
                     in = new BufferedInputStream(inputStream);
                     Translator.ImportResults importResults = translator.importArchive(in, mergeOverwrite);
                     importedSlug = importResults.importedSlug;
+                    alreadyExists = importResults.alreadyExists;
                     success = importResults.isSuccess();
                     if (success && importResults.mergeConflict) {
                         mergeConflict = MergeConflictsHandler.isTranslationMergeConflicted(importResults.importedSlug); // make sure we have actual merge conflicts
@@ -65,6 +69,7 @@ public class ImportProjectFromUriTask extends ManagedTask {
                     in = new BufferedInputStream(inputStream);
                     Translator.ImportResults importResults = translator.importArchive(in, mergeOverwrite);
                     importedSlug = importResults.importedSlug;
+                    alreadyExists = importResults.alreadyExists;
                     success = importResults.isSuccess();
                     if(success && importResults.mergeConflict) {
                         mergeConflict = MergeConflictsHandler.isTranslationMergeConflicted(importResults.importedSlug); // make sure we have actual merge conflicts
@@ -80,7 +85,7 @@ public class ImportProjectFromUriTask extends ManagedTask {
                 }
             }
         }
-        setResult(new ImportResults(path, readablePath, importedSlug, success, mergeConflict, !validExtension, isDocumentFile));
+        setResult(new ImportResults(path, readablePath, importedSlug, success, mergeConflict, !validExtension, isDocumentFile, alreadyExists));
     }
 
     /**
@@ -96,8 +101,10 @@ public class ImportProjectFromUriTask extends ManagedTask {
         public final boolean invalidFileName;
         public final boolean isDocumentFile;
         public final boolean success;
+        public final boolean alreadyExists;
 
-        ImportResults(Uri filePath, String readablePath, String importedSlug, boolean success, boolean mergeConflict, boolean invalidFileName, boolean isDocumentFile) {
+        ImportResults(Uri filePath, String readablePath, String importedSlug, boolean success, boolean mergeConflict,
+                      boolean invalidFileName, boolean isDocumentFile, boolean alreadyExists) {
             this.filePath = filePath;
             this.success = success;
             this.mergeConflict = mergeConflict;
@@ -105,6 +112,7 @@ public class ImportProjectFromUriTask extends ManagedTask {
             this.isDocumentFile = isDocumentFile;
             this.readablePath = readablePath;
             this.importedSlug = importedSlug;
+            this.alreadyExists = alreadyExists;
         }
     }
 }

--- a/app/src/main/java/com/door43/translationstudio/ui/home/ImportDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/ImportDialog.java
@@ -79,7 +79,7 @@ public class ImportDialog extends DialogFragment implements SimpleTaskWatcher.On
         getDialog().requestWindowFeature(Window.FEATURE_NO_TITLE);
         View v = inflater.inflate(R.layout.dialog_import, container, false);
 
-        Button importLocalButton = (Button)v.findViewById(R.id.import_target_translation);
+        Button importLocalProjectButton = (Button)v.findViewById(R.id.import_target_translation);
         Button importLocalUsfmButton = (Button)v.findViewById(R.id.import_usfm);
         Button importFromFriend = (Button)v.findViewById(R.id.import_from_device);
         Button importDoor43Button = (Button)v.findViewById(R.id.import_from_door43);
@@ -135,7 +135,7 @@ public class ImportDialog extends DialogFragment implements SimpleTaskWatcher.On
                 showDialogFragment(dialog, ImportFromDoor43Dialog.TAG);
             }
         });
-        importLocalButton.setOnClickListener(new View.OnClickListener() {
+        importLocalProjectButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 mMergeSelection = MergeOptions.NONE;
@@ -217,6 +217,10 @@ public class ImportDialog extends DialogFragment implements SimpleTaskWatcher.On
         });
     }
 
+    /**
+     * do an import from local file system
+     * @param doingUsfmImport
+     */
     private void doImportLocal(boolean doingUsfmImport) {
         String typeStr = null;
         Intent intent = new Intent(getActivity(), FileChooserActivity.class);
@@ -498,6 +502,10 @@ public class ImportDialog extends DialogFragment implements SimpleTaskWatcher.On
         showImportResults(message);
     }
 
+    /**
+     * show the import results message to user
+     * @param message
+     */
     private void showImportResults(String message) {
         mDialogShown = DialogShown.SHOW_IMPORT_RESULTS;
         mDialogMessage = message;

--- a/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
@@ -347,12 +347,12 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
                                 notifyImportFailed();
                                 importFailed = true;
                             }
+                            alreadyExisted = false;
                         }
                     } else {
                         Logger.e(this.getClass().getName(), "Failed to open the online backup");
                         notifyImportFailed();
                         importFailed = true;
-                        alreadyExisted = false;
                     }
                     FileUtilities.deleteQuietly(tempPath);
 

--- a/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
@@ -61,7 +61,8 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
     private static final String STATE_DIALOG_SHOWN = "state_dialog_shown";
     public static final String STATE_CLONE_URL = "state_clone_url";
     public static final String STATE_TARGET_TRANSLATION = "state_target_translation";
-    public static final String STATE_MERGE_OVERWRITE = "state_merge_overwrite";
+    public static final String STATE_MERGE_SELECTION = "state_merge_selection";
+    public static final String STATE_MERGE_CONFLICT = "state_merge_conflict";
 
     private SimpleTaskWatcher taskWatcher;
     private TranslationRepositoryAdapter adapter;
@@ -71,10 +72,11 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
     private File cloneDestDir;
     private EditText repoEditText;
     private EditText userEditText;
-    private eDialogShown mDialogShown = eDialogShown.NONE;
+    private DialogShown mDialogShown = DialogShown.NONE;
     private TargetTranslation mTargetTranslation;
-    private boolean mMergeOverwrite = false;
     private ProgressDialog mProgressDialog = null;
+    private ImportDialog.MergeOptions mMergeSelection = ImportDialog.MergeOptions.NONE;
+    private boolean mMergeConflicted = false;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, final Bundle savedInstanceState) {
@@ -162,9 +164,10 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
 
         // restore state
         if(savedInstanceState != null) {
-            mDialogShown = eDialogShown.fromInt(savedInstanceState.getInt(STATE_DIALOG_SHOWN, eDialogShown.NONE.getValue()));
+            mDialogShown = DialogShown.fromInt(savedInstanceState.getInt(STATE_DIALOG_SHOWN, DialogShown.NONE.getValue()));
             mCloneHtmlUrl = savedInstanceState.getString(STATE_CLONE_URL, null);
-            mMergeOverwrite = savedInstanceState.getBoolean(STATE_MERGE_OVERWRITE, false);
+            mMergeConflicted = savedInstanceState.getBoolean(STATE_MERGE_CONFLICT, false);
+            mMergeSelection = ImportDialog.MergeOptions.fromInt(savedInstanceState.getInt(STATE_MERGE_SELECTION, ImportDialog.MergeOptions.NONE.getValue()));
             String targetTranslationId = savedInstanceState.getString(STATE_TARGET_TRANSLATION, null);
             if(targetTranslationId != null) {
                 mTargetTranslation = App.getTranslator().getTargetTranslation(targetTranslationId);
@@ -209,15 +212,15 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
         String repoName = repo.getFullName().replace("/", "-");
         cloneDestDir = new File(App.context().getCacheDir(), repoName + System.currentTimeMillis() + "/");
         mCloneHtmlUrl = repo.getHtmlUrl();
-        cloneRepository(false);
+        cloneRepository(ImportDialog.MergeOptions.NONE);
     }
 
     /**
      * start a clone task
      */
-    private void cloneRepository(boolean overwriteExisting) {
+    private void cloneRepository(ImportDialog.MergeOptions mergeSelection) {
         showProgressDialog();
-        mMergeOverwrite = overwriteExisting;
+        mMergeSelection = mergeSelection;
         CloneRepositoryTask task = new CloneRepositoryTask(mCloneHtmlUrl, cloneDestDir);
         taskWatcher.watch(task);
         TaskManager.addTask(task, CloneRepositoryTask.TASK_ID);
@@ -239,7 +242,7 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
                 break;
 
             case MERGE_CONFLICT:
-                showMergeConflict(mTargetTranslation);
+                showMergeOverwritePrompt(mTargetTranslation);
                 break;
 
             case NONE:
@@ -309,25 +312,27 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
                 CloneRepositoryTask.Status status = ((CloneRepositoryTask)task).getStatus();
                 File tempPath = ((CloneRepositoryTask) task).getDestDir();
                 String cloneUrl = ((CloneRepositoryTask) task).getCloneUrl();
+                boolean alreadyExisted = false;
 
                 if(status == CloneRepositoryTask.Status.SUCCESS) {
                     Logger.i(this.getClass().getName(), "Repository cloned from " + cloneUrl);
                     tempPath = TargetTranslationMigrator.migrate(tempPath);
                     TargetTranslation tempTargetTranslation = TargetTranslation.open(tempPath);
                     boolean importFailed = false;
-                    boolean mergeConflicted = false;
+                    mMergeConflicted = false;
                     if (tempTargetTranslation != null) {
                         TargetTranslation existingTargetTranslation = translator.getTargetTranslation(tempTargetTranslation.getId());
-                        if( (existingTargetTranslation != null) && (!mMergeOverwrite)) {
+                        alreadyExisted = (existingTargetTranslation != null);
+                        if( alreadyExisted && (mMergeSelection != ImportDialog.MergeOptions.OVERWRITE)) {
                             // merge target translation
                             try {
                                 boolean success = existingTargetTranslation.merge(tempPath);
                                 if(!success) {
                                     if(MergeConflictsHandler.isTranslationMergeConflicted(existingTargetTranslation.getId())) {
-                                        mergeConflicted = true;
-                                        showMergeConflict(existingTargetTranslation);
+                                        mMergeConflicted = true;
                                     }
                                 }
+                                showMergeOverwritePrompt(existingTargetTranslation);
                             } catch (Exception e) {
                                 Logger.e(this.getClass().getName(), "Failed to merge the target translation", e);
                                 notifyImportFailed();
@@ -347,10 +352,11 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
                         Logger.e(this.getClass().getName(), "Failed to open the online backup");
                         notifyImportFailed();
                         importFailed = true;
+                        alreadyExisted = false;
                     }
                     FileUtilities.deleteQuietly(tempPath);
 
-                    if(!importFailed && !mergeConflicted) {
+                    if(!importFailed && !alreadyExisted) {
                         // todo: terrible hack. We should instead register a listener with the dialog
                         ((HomeActivity) getActivity()).notifyDatasetChanged();
 
@@ -380,7 +386,7 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
         } else if(task instanceof RegisterSSHKeysTask) {
             if(((RegisterSSHKeysTask)task).isSuccess()) {
                 Logger.i(this.getClass().getName(), "SSH keys were registered with the server");
-                cloneRepository(mMergeOverwrite);
+                cloneRepository(mMergeSelection);
             } else {
                 notifyImportFailed();
             }
@@ -392,24 +398,27 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
      * let user know there was a merge conflict
      * @param targetTranslation
      */
-    public void showMergeConflict(TargetTranslation targetTranslation) {
-        mDialogShown = eDialogShown.MERGE_CONFLICT;
+    public void showMergeOverwritePrompt(TargetTranslation targetTranslation) {
+        mDialogShown = DialogShown.MERGE_CONFLICT;
         mTargetTranslation = targetTranslation;
-        String message = getActivity().getString(R.string.import_merge_conflict_project_name, targetTranslation.getId());
+        int messageID = mMergeConflicted ? R.string.import_merge_conflict_project_name : R.string.import_project_already_exists;
+        String message = getActivity().getString(messageID, targetTranslation.getId());
         new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
                 .setTitle(R.string.merge_conflict_title)
                 .setMessage(message)
                 .setPositiveButton(R.string.merge_projects_label, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        mDialogShown = eDialogShown.NONE;
-                        doManualMerge();
+                        mDialogShown = DialogShown.NONE;
+                        if(mMergeConflicted) {
+                            doManualMerge();
+                        }
                     }
                 })
                 .setNeutralButton(R.string.title_cancel, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        mDialogShown = eDialogShown.NONE;
+                        mDialogShown = DialogShown.NONE;
                         resetToMasterBackup();
                         dialog.dismiss();
                     }
@@ -417,9 +426,9 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
                 .setNegativeButton(R.string.overwrite_projects_label, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        mDialogShown = eDialogShown.NONE;
+                        mDialogShown = DialogShown.NONE;
                         resetToMasterBackup(); // restore and now overwrite
-                        cloneRepository(true);
+                        cloneRepository(ImportDialog.MergeOptions.OVERWRITE);
                     }
                 }).show();
     }
@@ -449,13 +458,13 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
     }
 
     public void showAuthFailure() {
-        mDialogShown = eDialogShown.AUTH_FAILURE;
+        mDialogShown = DialogShown.AUTH_FAILURE;
         new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
                 .setTitle(R.string.error).setMessage(R.string.auth_failure_retry)
                 .setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        mDialogShown = eDialogShown.NONE;
+                        mDialogShown = DialogShown.NONE;
                         RegisterSSHKeysTask keyTask = new RegisterSSHKeysTask(true);
                         taskWatcher.watch(keyTask);
                         TaskManager.addTask(keyTask, RegisterSSHKeysTask.TASK_ID);
@@ -464,21 +473,21 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
                 .setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        mDialogShown = eDialogShown.NONE;
+                        mDialogShown = DialogShown.NONE;
                         notifyImportFailed();
                     }
                 }).show();
     }
 
     public void notifyImportFailed() {
-        mDialogShown = eDialogShown.IMPORT_FAILED;
+        mDialogShown = DialogShown.IMPORT_FAILED;
         new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
                 .setTitle(R.string.error)
                 .setMessage(R.string.restore_failed)
                 .setPositiveButton(R.string.dismiss, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        mDialogShown = eDialogShown.NONE;
+                        mDialogShown = DialogShown.NONE;
                     }
                 })
                 .show();
@@ -492,7 +501,8 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
         }
         out.putStringArray(STATE_REPOSITORIES, repoJsonList.toArray(new String[repoJsonList.size()]));
         out.putInt(STATE_DIALOG_SHOWN, mDialogShown.getValue());
-        out.putBoolean(STATE_MERGE_OVERWRITE, mMergeOverwrite);
+        out.putInt(STATE_MERGE_SELECTION, mMergeSelection.getValue());
+        out.putBoolean(STATE_MERGE_CONFLICT, mMergeConflicted);
         if(mCloneHtmlUrl != null) {
             out.putString(STATE_CLONE_URL, mCloneHtmlUrl);
         }
@@ -515,7 +525,7 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
     /**
      * for keeping track which dialog is being shown for orientation changes (not for DialogFragments)
      */
-    public enum eDialogShown {
+    public enum DialogShown {
         NONE(0),
         IMPORT_FAILED(1),
         AUTH_FAILURE(2),
@@ -523,7 +533,7 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
 
         private int _value;
 
-        eDialogShown(int Value) {
+        DialogShown(int Value) {
             this._value = Value;
         }
 
@@ -531,8 +541,8 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
             return _value;
         }
 
-        public static eDialogShown fromInt(int i) {
-            for (eDialogShown b : eDialogShown.values()) {
+        public static DialogShown fromInt(int i) {
+            for (DialogShown b : DialogShown.values()) {
                 if (b.getValue() == i) {
                     return b;
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -965,4 +965,5 @@ Do you want to enable SD card access?  If so then:
     <string name="do_not_show_again">Don\'t show again</string>
     <string name="pref_title_check_hardware_requirements">Check Hardware Requirements</string>
     <string name="pref_description_check_hardware_requirements">Check for suggested hardware when starting the app</string>
+    <string name="import_project_already_exists">This project (<xliff:g example="en_ulb_reg" id="translation">%1$s</xliff:g>) already exists locally. How would you like to proceed?</string>
 </resources>


### PR DESCRIPTION
Fix #2188 prompt before merge on import even if there is no merge conflict.

Changes in this pull request:
- ImportDialog, ImportFromDoor43Dialog - keep track of previous merge option selection (overwrite or merge) and if last merge had conflict. Now prompt user for import options if there was an existing project (not just on merge conflict).
- Translator.importArchive(), ImportProjectFromUriTask - now save flag if a project already existed before import.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2205)
<!-- Reviewable:end -->
