### PR TITLE
Fix #2188 fix to show import success on non-conflicted merge

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/home/HomeActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/HomeActivity.java
@@ -1,17 +1,14 @@
 package com.door43.translationstudio.ui.home;
 
-import android.app.ActivityManager;
 import android.app.DialogFragment;
 import android.app.Fragment;
 import android.app.FragmentTransaction;
 import android.app.ProgressDialog;
 import android.content.ContentResolver;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.Nullable;
@@ -534,7 +531,7 @@ public class HomeActivity extends BaseActivity implements SimpleTaskWatcher.OnFi
         }
 
         new AlertDialog.Builder(this, R.style.AppTheme_Dialog)
-                .setTitle(success ? R.string.title_import_Success : R.string.title_import_Failed)
+                .setTitle(success ? R.string.title_import_success : R.string.title_import_failed)
                 .setMessage(message)
                 .setPositiveButton(R.string.label_ok, new DialogInterface.OnClickListener() {
                     @Override

--- a/app/src/main/java/com/door43/translationstudio/ui/home/ImportDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/ImportDialog.java
@@ -368,7 +368,7 @@ public class ImportDialog extends DialogFragment implements SimpleTaskWatcher.On
             ResourceContainer container = App.getLibrary().importResourceContainer(dir);
             new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
                     .setTitle(R.string.success)
-                    .setMessage(R.string.title_import_Success)
+                    .setMessage(R.string.title_import_success)
                     .setPositiveButton(R.string.dismiss, null)
                     .show();
         } catch (Exception e) {
@@ -417,6 +417,8 @@ public class ImportDialog extends DialogFragment implements SimpleTaskWatcher.On
                         mMergeSelection = MergeOptions.OVERWRITE;
                         if(mMergeConflicted) {
                             doManualMerge();
+                        } else {
+                            showImportResults(R.string.title_import_success, null);
                         }
                     }
                 })

--- a/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/ImportFromDoor43Dialog.java
@@ -359,12 +359,7 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
                     if(!importFailed && !alreadyExisted) {
                         // todo: terrible hack. We should instead register a listener with the dialog
                         ((HomeActivity) getActivity()).notifyDatasetChanged();
-
-                        new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
-                                .setTitle(R.string.import_from_door43)
-                                .setMessage(R.string.title_import_Success)
-                                .setPositiveButton(R.string.dismiss, null)
-                                .show();
+                        showImportSuccess();
                     }
                 } else if(status == CloneRepositoryTask.Status.AUTH_FAILURE) {
                     Logger.i(this.getClass().getName(), "Authentication failed");
@@ -395,6 +390,17 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
     }
 
     /**
+     * tell user that import was successful
+     */
+    public void showImportSuccess() {
+        new AlertDialog.Builder(getActivity(), R.style.AppTheme_Dialog)
+                .setTitle(R.string.import_from_door43)
+                .setMessage(R.string.title_import_success)
+                .setPositiveButton(R.string.dismiss, null)
+                .show();
+    }
+
+    /**
      * let user know there was a merge conflict
      * @param targetTranslation
      */
@@ -412,6 +418,8 @@ public class ImportFromDoor43Dialog extends DialogFragment implements SimpleTask
                         mDialogShown = DialogShown.NONE;
                         if(mMergeConflicted) {
                             doManualMerge();
+                        } else {
+                            showImportSuccess();
                         }
                     }
                 })

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -775,8 +775,8 @@ Do you want to enable SD card access?  If so then:
     <string name="chapter_count_invalid">Expected <xliff:g example="16" id="chunk_count">%1$s</xliff:g> chapters, but last chapter was <xliff:g example="15" id="chapter_count">%2$s</xliff:g></string>
     <string name="no_chapter">No chapter found</string>
     <string name="label_restore">Restore</string>
-    <string name="title_import_Success">Import Success</string>
-    <string name="title_import_Failed">Import Failed!</string>
+    <string name="title_import_success">Import Success</string>
+    <string name="title_import_failed">Import Failed!</string>
     <string name="import_project_success">Success Importing <xliff:g example="Mark" id="project">%1$s</xliff:g> from:\n<xliff:g example="/downloads/file.tx" id="path">%2$s</xliff:g></string>
     <string name="table_of_contents">Table of Contents </string>
     <string name="license_pdf" translatable="false">


### PR DESCRIPTION
Fix #2188 fix to show import success on non-conflicted merge

Changes in this pull request:
- ImportFromDoor43Dialog, ImportDialog - fix to show import success when merge not conflicted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2210)
<!-- Reviewable:end -->
