### PR TITLE
Fix #2222 crash on resolve conflict

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -519,6 +519,7 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
                     item.hasMergeConflicts = MergeConflictsHandler.isMergeConflicted(selectedText);
                     item.mergeItemSelected = -1;
                     item.isEditing = false;
+                    triggerNotifyDataSetChanged();
                     updateMergeConflict();
                 }
             }


### PR DESCRIPTION
Fix #2222 crash on resolve conflict

Changes in this pull request:
- ReviewModeAdapter - trigger redraw of card when merge conflict is resolved so that card type is changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2225)
<!-- Reviewable:end -->
