### PR TITLE
Fix #2221 app exits after upload conflict

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.java
@@ -873,7 +873,7 @@ public class BackupDialog extends DialogFragment implements SimpleTaskWatcher.On
             args.putInt(App.EXTRA_VIEW_MODE, TranslationViewMode.REVIEW.ordinal());
             intent.putExtras(args);
             startActivity(intent);
-            getActivity().finish();
+            BackupDialog.this.dismiss();
         }
     }
 


### PR DESCRIPTION
Fix #2221 app exits after upload conflict

Changes in this pull request:
- BackupDialog - fix bug that home activity was being closed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2227)
<!-- Reviewable:end -->
