### PR TITLE
Fix #2229 crash on resolve conflict

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ReviewModeAdapter.java
@@ -519,6 +519,9 @@ public class ReviewModeAdapter extends ViewModeAdapter<ReviewHolder> implements 
                     item.hasMergeConflicts = MergeConflictsHandler.isMergeConflicted(selectedText);
                     item.mergeItemSelected = -1;
                     item.isEditing = false;
+                    if(!item.hasMergeConflicts && mMergeConflictFilterEnabled) {
+                        mFilteredItems.remove(item); // if in merge conflict mode and merge conflicts resolved, remove item
+                    }
                     triggerNotifyDataSetChanged();
                     updateMergeConflict();
                 }


### PR DESCRIPTION
Fix #2229 crash on resolve conflict

Changes in this pull request:
- ReviewModeAdapter - fix for resolving conflict when in merge conflict mode to remove item from filtered items list to prevent starting redraw of card while merge filter being recalculated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/ts-android/2234)
<!-- Reviewable:end -->
